### PR TITLE
Disable screensaver settings by default

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -46,13 +46,6 @@
 		<setting id="audio_playback_bitrate" type="select" label="30418" values="128|160|192|256|320|384|448|640" default="256" visible="true"/>
 		<setting id="audio_max_channels" type="slider" label="30420" default="8" range="2,1,8" option="int" visible="true"/>
 
-		<!--
-		<setting label="30209" type="lsep"/>
-		<setting type="sep" />
-		<setting id="smbusername" type="text" label="30007" default="" enable="true" visible="true"/>
-		<setting id="smbpassword" type="text" label="30008" default="" option="hidden" enable="true" visible="true"/>
-		-->
-
 	</category>
 	<category label="30214">
 
@@ -74,8 +67,8 @@
 
 		<setting label="30329" type="lsep"/>
 		<setting type="sep" />
-		<setting id="stopPlaybackOnScreensaver" type="bool" label="30332" default="true" visible="true" enable="true" />
-		<setting id="changeUserOnScreenSaver" type="bool" label="30330" default="true" visible="true" enable="true" />
+		<setting id="stopPlaybackOnScreensaver" type="bool" label="30332" default="false" visible="true" enable="true" />
+		<setting id="changeUserOnScreenSaver" type="bool" label="30330" default="false" visible="true" enable="true" />
 		<setting id="cacheImagesOnScreenSaver" type="bool" label="30333" default="true" visible="true" enable="true" />
 		<setting id="cacheImagesOnScreenSaver_interval" type="slider" label="30400" default="0" range="0,1,60" option="int" visible="true"/>
 


### PR DESCRIPTION
Assumed fix for #81 and #83 for future clean installs.  Disables the "Show user select on screensaver" and "Stop playback on screensaver" settings.

Also removes dead/commented out settings.