### PR TITLE
Only set the cast if they exist

### DIFF
--- a/resources/lib/item_functions.py
+++ b/resources/lib/item_functions.py
@@ -471,7 +471,7 @@ def add_gui_item(url, item_details, display_options, folder=True, default_sort=F
     info_labels = {}
 
     # add cast
-    if item_details.cast is not None:
+    if item_details.cast:
         if kodi_version >= 17:
             list_item.setCast(item_details.cast)
         else:


### PR DESCRIPTION
setting `list_item.setCast()` to an empty list appears to be throwing the sort methods for a loop.  Only set the cast when they actually exist (we're getting an empty list for music tracks)

Fixes #79 