### PR TITLE
Rework user data storage

### DIFF
--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -6,7 +6,6 @@ import xbmcaddon
 
 import requests
 import json
-import hashlib
 from six.moves.urllib.parse import urlparse
 from base64 import b64encode
 from collections import defaultdict
@@ -448,7 +447,6 @@ class DownloadUtils:
             return user_details.get('token')
 
         settings = xbmcaddon.Addon()
-        server_address = settings.getSetting("server_address")
 
         url = "{server}/Users/AuthenticateByName"
 

--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -6,6 +6,7 @@ import xbmcaddon
 
 import requests
 import json
+import hashlib
 from six.moves.urllib.parse import urlparse
 from base64 import b64encode
 from collections import defaultdict
@@ -473,12 +474,11 @@ class DownloadUtils:
             log.debug("User NOT Authenticated")
 
     def get_auth_header(self, authenticate=True):
-        txt_mac = get_device_id()
+        device_id = get_device_id()
         version = get_version()
         client = 'Kodi JellyCon'
 
         settings = xbmcaddon.Addon()
-        username = settings.getSetting('username')
         device_name = settings.getSetting('deviceName')
         # remove none ascii chars
         device_name = py2_decode(device_name)
@@ -492,12 +492,12 @@ class DownloadUtils:
         headers["Accept-Charset"] = "UTF-8,*"
 
         if authenticate is False:
-            auth_string = 'MediaBrowser Client="{}",Device="{}",DeviceId="{}{}",Version="{}'.format(client, device_name, txt_mac, username, version)
+            auth_string = 'MediaBrowser Client="{}",Device="{}",DeviceId="{}",Version="{}'.format(client, device_name, device_id, version)
             headers['X-Emby-Authorization'] = auth_string
             return headers
         else:
             userid = self.get_user_id()
-            auth_string = 'MediaBrowser UserId="{}",Client="{}",Device="{}",DeviceId="{}{}",Version="{}"'.format(userid, client, device_name, txt_mac, username, version)
+            auth_string = 'MediaBrowser UserId="{}",Client="{}",Device="{}",DeviceId="{}",Version="{}"'.format(userid, client, device_name, device_id, version)
             headers['X-Emby-Authorization'] = auth_string
 
             auth_token = self.authenticate()

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -14,8 +14,8 @@ import xbmcgui
 import xbmcaddon
 import xbmc
 
-from .downloadutils import DownloadUtils, load_user_details
-from .utils import convert_size, translate_string, get_version
+from .downloadutils import DownloadUtils
+from .utils import convert_size, translate_string, get_version, load_user_details
 from .item_functions import get_art
 from .kodi_utils import HomeWindow
 from .datamanager import DataManager, clear_cached_server_data
@@ -495,8 +495,8 @@ def show_menu(params):
         log.debug("Refresh Server Responce: {0}".format(res))
 
     elif selected_action == "hide":
-        user_details = load_user_details(settings)
-        user_name = user_details["username"]
+        user_details = load_user_details()
+        user_name = user_details["user_name"]
         hide_tag_string = "hide-" + user_name
         url = "{server}/Items/" + item_id + "/Tags/Add"
         post_tag_data = {"Tags": [{"Name": hide_tag_string}]}

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -278,6 +278,7 @@ def check_server(force=False, change_user=False, notify=False):
                     return
 
             # Ask for password if user has one
+            password = ''
             if secured and not user_details.get('token'):
                 kb = xbmc.Keyboard()
                 kb.setHeading(translate_string(30006))
@@ -285,8 +286,6 @@ def check_server(force=False, change_user=False, notify=False):
                 kb.doModal()
                 if kb.isConfirmed():
                     password = kb.getText()
-            else:
-                password = ''
 
             # TODO: Make the authenticate function operate normally.  Network rework
             home_window.set_property('password', password)

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -5,19 +5,16 @@ import socket
 import json
 import requests
 import time
-import hashlib
 from datetime import datetime
 
 import xbmcaddon
 import xbmcgui
 import xbmc
-from six import ensure_binary
-from kodi_six.utils import py2_decode
 
 from .kodi_utils import HomeWindow
-from .downloadutils import DownloadUtils, save_user_details, load_user_details
+from .downloadutils import DownloadUtils
 from .loghandler import LazyLogger
-from .utils import datetime_from_string, translate_string, get_version
+from .utils import datetime_from_string, translate_string, get_version, load_user_details
 
 log = LazyLogger(__name__)
 
@@ -211,7 +208,7 @@ def check_server(force=False, change_user=False, notify=False):
                 if server_url:
                     kb.setDefault(server_url)
                 else:
-                    kb.setDefault("http://<server address>:8096")
+                    kb.setDefault("http://")
                 kb.doModal()
                 if kb.isConfirmed():
                     server_url = kb.getText()
@@ -245,122 +242,29 @@ def check_server(force=False, change_user=False, notify=False):
         something_changed = True
 
     # do we need to change the user
-    user_details = load_user_details(settings)
-    current_username = user_details.get("username", "")
-    current_username = py2_decode(current_username)
+    current_username = settings.getSetting('username')
 
     # if asked or we have no current user then show user selection screen
     if something_changed or change_user or len(current_username) == 0:
 
         # stop playback when switching users
         xbmc.Player().stop()
-        du = DownloadUtils()
 
-        # get a list of users
-        log.debug("Getting user list")
-        result = du.download_url(server_url + "/Users/Public?format=json", authenticate=False)
+        users, user_selection = user_select(server_url, current_username)
 
-        log.debug("jsonData: {0}".format(py2_decode(result)))
-
-        selected_id = -1
-        users = []
-        for user in result:
-            config = user.get("Configuration")
-            if config is not None:
-                if config.get("IsHidden", False) is False:
-                    name = user.get("Name")
-                    admin = user.get("Policy", {}).get("IsAdministrator", False)
-
-                    time_ago = ""
-                    last_active = user.get("LastActivityDate")
-                    if last_active:
-                        last_active_date = datetime_from_string(last_active)
-                        log.debug("LastActivityDate: {0}".format(last_active_date))
-                        ago = datetime.now() - last_active_date
-                        log.debug("LastActivityDate: {0}".format(ago))
-                        days = divmod(ago.seconds, 86400)
-                        hours = divmod(days[1], 3600)
-                        minutes = divmod(hours[1], 60)
-                        log.debug("LastActivityDate: {0} {1} {2}".format(days[0], hours[0], minutes[0]))
-                        if days[0]:
-                            time_ago += " %sd" % days[0]
-                        if hours[0]:
-                            time_ago += " %sh" % hours[0]
-                        if minutes[0]:
-                            time_ago += " %sm" % minutes[0]
-                        time_ago = time_ago.strip()
-                        if not time_ago:
-                            time_ago = "Active: now"
-                        else:
-                            time_ago = "Active: %s ago" % time_ago
-                        log.debug("LastActivityDate: {0}".format(time_ago))
-
-                    user_item = xbmcgui.ListItem(name)
-                    user_image = du.get_user_artwork(user, 'Primary')
-                    if not user_image:
-                        user_image = "DefaultUser.png"
-                    art = {"Thumb": user_image}
-                    user_item.setArt(art)
-                    user_item.setLabel2("TEST")
-
-                    sub_line = time_ago
-
-                    if user.get("HasPassword", False) is True:
-                        sub_line += ", Password"
-                        user_item.setProperty("secure", "true")
-
-                        m = hashlib.md5()
-                        m.update(ensure_binary(name))
-                        hashed_username = m.hexdigest()
-                        saved_password = settings.getSetting("saved_user_password_" + hashed_username)
-                        if saved_password:
-                            sub_line += ": Saved"
-
-                    else:
-                        user_item.setProperty("secure", "false")
-
-                    if admin:
-                        sub_line += ", Admin"
-                    else:
-                        sub_line += ", User"
-
-                    user_item.setProperty("manual", "false")
-                    user_item.setLabel2(sub_line)
-                    users.append(user_item)
-
-                    if current_username == name:
-                        selected_id = len(users) - 1
-
-        if current_username:
-            selection_title = translate_string(30180) + " (" + current_username + ")"
-        else:
-            selection_title = translate_string(30180)
-
-        # add manual login
-        user_item = xbmcgui.ListItem(translate_string(30365))
-        art = {"Thumb": "DefaultUser.png"}
-        user_item.setArt(art)
-        user_item.setLabel2(translate_string(30366))
-        user_item.setProperty("secure", "true")
-        user_item.setProperty("manual", "true")
-        users.append(user_item)
-
-        return_value = xbmcgui.Dialog().select(selection_title,
-                                               users,
-                                               preselect=selected_id,
-                                               autoclose=20000,
-                                               useDetails=True)
-
-        if return_value > -1 and return_value != selected_id:
+        if user_selection > -1:
 
             something_changed = True
-            selected_user = users[return_value]
+            selected_user = users[user_selection]
+            selected_user_name = selected_user.getLabel()
             secured = selected_user.getProperty("secure") == "true"
             manual = selected_user.getProperty("manual") == "true"
-            selected_user_name = selected_user.getLabel()
 
-            log.debug("Selected User Name: {0} : {1}".format(return_value, selected_user_name))
+            home_window = HomeWindow()
+            home_window.set_property('user_name', selected_user_name)
+            user_details = load_user_details()
 
+            # If using a manual login, ask for username
             if manual:
                 kb = xbmc.Keyboard()
                 kb.setHeading(translate_string(30005))
@@ -373,54 +277,122 @@ def check_server(force=False, change_user=False, notify=False):
                 else:
                     return
 
-            if secured:
-                # we need a password, check the settings first
-                m = hashlib.md5()
-                m.update(selected_user_name.encode())
-                hashed_username = m.hexdigest()
-                saved_password = settings.getSetting("saved_user_password_" + hashed_username)
-                allow_password_saving = settings.getSetting("allow_password_saving") == "true"
-
-                # if not saving passwords but have a saved ask to clear it
-                if not allow_password_saving and saved_password:
-                    clear_password = xbmcgui.Dialog().yesno(translate_string(30368), translate_string(30369))
-                    if clear_password:
-                        settings.setSetting("saved_user_password_" + hashed_username, "")
-
-                if saved_password:
-                    log.debug("Saving username and password: {0}".format(selected_user_name))
-                    log.debug("Using stored password for user: {0}".format(hashed_username))
-                    save_user_details(settings, selected_user_name, saved_password)
-
-                else:
-                    kb = xbmc.Keyboard()
-                    kb.setHeading(translate_string(30006))
-                    kb.setHiddenInput(True)
-                    kb.doModal()
-                    if kb.isConfirmed():
-                        log.debug("Saving username and password: {0}".format(selected_user_name))
-                        save_user_details(settings, selected_user_name, kb.getText())
-
-                        # should we save the password
-                        if allow_password_saving:
-                            save_password = xbmcgui.Dialog().yesno(translate_string(30363), translate_string(30364))
-                            if save_password:
-                                log.debug("Saving password for fast user switching: {0}".format(hashed_username))
-                                settings.setSetting("saved_user_password_" + hashed_username, kb.getText())
+            # Ask for password if user has one
+            if secured and not user_details.get('token'):
+                kb = xbmc.Keyboard()
+                kb.setHeading(translate_string(30006))
+                kb.setHiddenInput(True)
+                kb.doModal()
+                if kb.isConfirmed():
+                    password = kb.getText()
             else:
-                log.debug("Saving username with no password: {0}".format(selected_user_name))
-                save_user_details(settings, selected_user_name, "")
+                password = ''
+
+            # TODO: Make the authenticate function operate normally.  Network rework
+            home_window.set_property('password', password)
 
         if something_changed:
             home_window = HomeWindow()
-            home_window.clear_property("userid")
-            home_window.clear_property("AccessToken")
-            home_window.clear_property("userimage")
             home_window.clear_property("jellycon_widget_reload")
-            du = DownloadUtils()
             du.authenticate()
-            du.get_user_id()
             xbmc.executebuiltin("ActivateWindow(Home)")
             if "estuary_jellycon" in xbmc.getSkinDir():
                 xbmc.executebuiltin("SetFocus(9000, 0, absolute)")
             xbmc.executebuiltin("ReloadSkin()")
+
+
+def user_select(server_url, current_username):
+    '''
+    Display user selection screen
+    '''
+    du = DownloadUtils()
+
+    # Retrieve list of public users from server
+    result = du.download_url('{}/Users/Public'.format(server_url), authenticate=False)
+
+    # Build user display
+    selected_id = -1
+    users = []
+    for user in result:
+        user_item = create_user_listitem(du, user)
+        if user_item:
+            users.append(user_item)
+        name = user.get("Name")
+
+        # Highlight currently logged in user
+        if current_username == name:
+            selected_id = len(users) - 1
+
+    if current_username:
+        selection_title = translate_string(30180) + " (" + current_username + ")"
+    else:
+        selection_title = translate_string(30180)
+
+    # Add manual login item
+    user_item = xbmcgui.ListItem(translate_string(30365))
+    art = {"Thumb": "DefaultUser.png"}
+    user_item.setArt(art)
+    user_item.setLabel2(translate_string(30366))
+    user_item.setProperty("secure", "true")
+    user_item.setProperty("manual", "true")
+    users.append(user_item)
+
+    user_selection = xbmcgui.Dialog().select(selection_title,
+                                           users,
+                                           preselect=selected_id,
+                                           autoclose=20000,
+                                           useDetails=True)
+
+    return (users, user_selection)
+
+
+def create_user_listitem(du, user):
+    '''
+    Create a user listitem for the user selection screen
+    '''
+    config = user.get("Configuration")
+    if config is not None:
+        name = user.get("Name")
+        time_ago = ""
+        last_active = user.get("LastActivityDate")
+        # Calculate how long it's been since the user was last active
+        if last_active:
+            last_active_date = datetime_from_string(last_active)
+            ago = datetime.now() - last_active_date
+            # Check days
+            if ago.days > 0:
+                time_ago += ' {}d'.format(ago.days)
+            # Check minutes
+            if ago.seconds > 60:
+                hours = 0
+                # Check hours
+                if ago.seconds > 3600:
+                    hours = int(ago.seconds/3600)
+                    time_ago += ' {}h'.format(hours)
+                minutes = int((ago.seconds - (hours * 3600)) / 60)
+                time_ago += ' {}m'.format(minutes)
+            time_ago = time_ago.strip()
+            if not time_ago:
+                time_ago = "Active: now"
+            else:
+                time_ago = "Active: {} ago".format(time_ago)
+
+        user_item = xbmcgui.ListItem(name)
+        user_image = du.get_user_artwork(user, 'Primary')
+        if not user_image:
+            user_image = "DefaultUser.png"
+        art = {"Thumb": user_image}
+        user_item.setArt(art)
+
+        sub_line = time_ago
+
+        if user.get("HasPassword", False) is True:
+            user_item.setProperty("secure", "true")
+        else:
+            user_item.setProperty("secure", "false")
+
+        user_item.setProperty("manual", "false")
+        user_item.setLabel2(sub_line)
+
+        return user_item
+    return None

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -12,11 +12,11 @@ import random
 import json
 import time
 import math
+import os
 from datetime import datetime
-import calendar
 import re
 from uuid import uuid4
-from six import ensure_text, ensure_binary
+from six import ensure_text, ensure_binary, text_type
 from six.moves.urllib.parse import urlencode
 
 from .loghandler import LazyLogger
@@ -80,18 +80,15 @@ def send_event_notification(method, data=None, hexlify=False):
 
 def datetime_from_string(time_string):
 
+    # Builtin python library can't handle ISO-8601 well. Make it compatible
     if time_string[-1:] == "Z":
         time_string = re.sub("[0-9]{1}Z", " UTC", time_string)
     elif time_string[-6:] == "+00:00":
         time_string = re.sub("[0-9]{1}\+00:00", " UTC", time_string)
-    log.debug("New Time String : {0}".format(time_string))
 
-    start_time = time.strptime(time_string, "%Y-%m-%dT%H:%M:%S.%f %Z")
-    dt = datetime(*(start_time[0:6]))
-    timestamp = calendar.timegm(dt.timetuple())
-    local_dt = datetime.fromtimestamp(timestamp)
-    local_dt.replace(microsecond=dt.microsecond)
-    return local_dt
+    dt = datetime.strptime(time_string, "%Y-%m-%dT%H:%M:%S.%f %Z")
+
+    return dt
 
 
 def convert_size(size_bytes):
@@ -128,8 +125,7 @@ def get_device_id():
     guid.close()
 
     if not client_id:
-        # Needs to be captilized for backwards compat
-        client_id = uuid4().hex.upper()
+        client_id = uuid4().hex
         log.debug("Generating a new guid: {0}".format(client_id))
         guid = xbmcvfs.File(jellyfin_guid_path, 'w')
         guid.write(client_id)
@@ -146,3 +142,68 @@ def get_version():
     addon = xbmcaddon.Addon()
     version = addon.getAddonInfo("version")
     return version
+
+
+def save_user_details(user_name, user_id, token):
+    settings = xbmcaddon.Addon()
+    save_user_to_settings = settings.getSetting('save_user_to_settings') == 'true'
+    addon_data = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
+
+    # Save to a config file for reference later if desired
+    if save_user_to_settings:
+        try:
+            with open(os.path.join(addon_data, 'auth.json'), 'rb') as infile:
+                auth_data = json.load(infile)
+        except:
+            # File doesn't exist or is empty
+            auth_data = {}
+
+        auth_data[user_name] = {
+            'user_id': user_id,
+            'token': token
+        }
+
+        with open(os.path.join(addon_data, 'auth.json'), 'wb') as outfile:
+            data = json.dumps(auth_data, sort_keys=True, indent=4, ensure_ascii=False)
+            if isinstance(data, text_type):
+                data = data.encode('utf-8')
+            outfile.write(data)
+
+    # Make the username available for easy lookup
+    window = HomeWindow()
+    settings.setSetting('username', user_name)
+    window.set_property('user_name', user_name)
+
+
+def load_user_details():
+    settings = xbmcaddon.Addon()
+    window = HomeWindow()
+    # Check current variables first, then check settings
+    user_name = window.get_property('user_name')
+    if not user_name:
+        user_name = settings.getSetting('username')
+        #settings_user_name = settings.getSetting('username')
+    save_user_to_settings = settings.getSetting('save_user_to_settings') == 'true'
+    addon_data = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
+
+    if save_user_to_settings:
+        try:
+            with open(os.path.join(addon_data, 'auth.json'), 'rb') as infile:
+                auth_data = json.load(infile)
+        except:
+            # File doesn't exist yet
+            return {}
+
+        user_data = auth_data.get(user_name, {})
+        user_id = user_data.get('user_id')
+        auth_token = user_data.get('token')
+
+        # Payload to return to calling function
+        user_details = {}
+        user_details['user_name'] = user_name
+        user_details['user_id'] = user_id
+        user_details['token'] = auth_token
+        return user_details
+
+    else:
+        return {}

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -13,6 +13,7 @@ import json
 import time
 import math
 import os
+import hashlib
 from datetime import datetime
 import re
 from uuid import uuid4
@@ -113,10 +114,12 @@ def translate_string(string_id):
 def get_device_id():
 
     window = HomeWindow()
+    username = window.get_property('username')
     client_id = window.get_property("client_id")
+    hashed_name = hashlib.md5(username.encode()).hexdigest()
 
     if client_id:
-        return client_id
+        return '{}-{}'.format(client_id, hashed_name)
 
     jellyfin_guid_path = py2_decode(xbmc.translatePath("special://temp/jellycon_guid"))
     log.debug("jellyfin_guid_path: {0}".format(jellyfin_guid_path))
@@ -135,7 +138,7 @@ def get_device_id():
         log.debug("jellyfin_client_id: {0}".format(client_id))
 
     window.set_property("client_id", client_id)
-    return client_id
+    return '{}-{}'.format(client_id, hashed_name)
 
 
 def get_version():

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -14,7 +14,6 @@
 		<setting type="sep" />
 		<setting label="30012" type="action" action="RunScript(plugin.video.jellycon,0,?mode=CHANGE_USER)" option="close"/>
 		<setting id="username" type="text" label="30024" />
-		<setting id="password" type="text" option="hidden" label="30025" />
 		<setting id="save_user_to_settings" type="bool" label="30378" default="true" visible="true" enable="true" />
 		<setting id="allow_password_saving" type="bool" label="30367" default="true" visible="true" enable="true" />
 

--- a/service.py
+++ b/service.py
@@ -8,7 +8,7 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 
-from resources.lib.downloadutils import DownloadUtils, save_user_details
+from resources.lib.downloadutils import DownloadUtils
 from resources.lib.loghandler import LazyLogger
 from resources.lib.play_utils import Service, PlaybackService, send_progress
 from resources.lib.kodi_utils import HomeWindow


### PR DESCRIPTION
Stop storing user passwords in plain text.  Change some of the user flow to be smoother, but a lot of it is too tightly tied to network functions and needs to wait until that refactor happens.  Will force users to re-authenticate when released because the migration path in code would be super ugly.  Also possibly fixes an issue with using multiple users not authenticating properly