### PR TITLE
Ensure server is present in API requests

### DIFF
--- a/resources/lib/jellyfin.py
+++ b/resources/lib/jellyfin.py
@@ -27,6 +27,11 @@ class API:
         if 'x-mediabrowser-token' not in self.headers:
             self.create_headers()
 
+        # Fixes initial login where class is initialized before wizard completes
+        if not self.server:
+            self.settings = xbmcaddon.Addon()
+            self.server = self.settings.getSetting('server_address')
+
         url = '{}{}'.format(self.server, path)
 
         r = requests.get(url, headers=self.headers, verify=self.verify_cert)


### PR DESCRIPTION
During initial login some background tasks are failing because the API class is being initialized before the setup wizard has completed and populated settings