### PR TITLE
Add quick connect authentication

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1087,3 +1087,11 @@ msgstr "Use cached widget data"
 msgctxt "#30442"
 msgid "Simple new content check"
 msgstr "Simple new content check"
+
+msgctxt "#30443"
+msgid "Quick Connect"
+msgstr "Quick Connect"
+
+msgctxt "#30444"
+msgid "Login using Quick Connect"
+msgstr "Login using Quick Connect"

--- a/resources/lib/dialogs.py
+++ b/resources/lib/dialogs.py
@@ -203,3 +203,43 @@ class PlayNextDialog(xbmcgui.WindowXMLDialog):
 
     def get_play_called(self):
         return self.play_called
+
+
+class QuickConnectDialog(xbmcgui.WindowXMLDialog):
+    connect_method = -1
+
+    def __init__(self, *args, **kwargs):
+        xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+        log.debug("QuickConnectDialog INITIALISED")
+
+        self.code = ''
+
+    def onInit(self):
+        self.action_exitkeys_id = [10, 13]
+
+        message_control = self.getControl(3)
+        message_control.setText(self.code)
+
+        message_control = self.getControl(4)
+        message_control.setLabel(translate_string(30443))
+
+        self.getControl(3010).setLabel(translate_string(30444))
+        self.getControl(3011).setLabel(translate_string(30365))
+
+    def onFocus(self, controlId):
+        pass
+
+    def doAction(self, actionID):
+        pass
+
+    def onClick(self, controlID):
+
+        if controlID == 3010:
+            self.connect_method = 1
+            self.close()
+        if controlID == 3011:
+            self.connect_method = 0
+            self.close()
+
+    def getConnectMethod(self):
+        return self.connect_method

--- a/resources/skins/default/720p/QuickConnectDialog.xml
+++ b/resources/skins/default/720p/QuickConnectDialog.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<window id="3301" type="dialog">
+    <defaultcontrol always="true">3010</defaultcontrol>
+    <zorder>2</zorder>
+    <coordinates>
+        <system>1</system>
+        <left>450</left>
+        <top>200</top>
+    </coordinates>
+    <controls>
+
+        <control type="image">
+            <left>0</left>
+            <top>0</top>
+            <width>400</width>
+            <height>270</height>
+            <texture border="40">bg.png</texture>
+        </control>
+
+        <control type="label" id="4">
+            <left>20</left>
+            <top>5</top>
+            <width>360</width>
+            <height>50</height>
+            <label>Heading</label>
+            <font>font45_title</font>
+            <align>center</align>
+        </control>
+
+        <control type="textbox" id="3">
+            <left>20</left>
+            <top>65</top>
+            <width>360</width>
+            <height>50</height>
+            <font>font45</font>
+            <align>center</align>
+        </control>
+
+        <control type="button" id="3010">
+            <texturenofocus border="1" colordiffuse="ff161616">white.png</texturenofocus>
+            <texturefocus border="1" colordiffuse="ff525252">white.png</texturefocus>
+            <left>20</left>
+            <top>135</top>
+            <width>360</width>
+            <height>40</height>
+            <label></label>
+            <onup></onup>
+            <ondown>3011</ondown>
+            <font>font14</font>
+            <align>center</align>
+        </control>
+
+        <control type="button" id="3011">
+            <texturenofocus border="1" colordiffuse="ff161616">white.png</texturenofocus>
+            <texturefocus border="1" colordiffuse="ff525252">white.png</texturefocus>		
+            <left>20</left>
+            <top>195</top>
+            <width>360</width>
+            <height>40</height>
+            <label></label>
+            <onup>3010</onup>
+            <ondown>3012</ondown>
+            <font>font14</font>
+            <align>center</align>
+        </control>
+
+    </controls>
+</window>


### PR DESCRIPTION
Fixes #146.  Defaults to using quick connect if it's enabled on the server with a fallback option to the old manual wizard selection if it fails or times out.

Note: Requires server version 10.8 or greater.  Does not work with the quick connect implementation in 10.7