### PR TITLE
Make sure manual login shows when connecting to a 10.7 server

### DIFF
--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -280,7 +280,7 @@ def quick_connect(api):
 
     result = api.get('/QuickConnect/Initiate')
 
-    if not isinstance(result, dict):
+    if not isinstance(result, dict) or not result:
         log.debug('Quick connect is disabled on the server')
         return {}
 


### PR DESCRIPTION
This quick connect implementation only works in 10.8 or newer, so account for the response from 10.7