### PR TITLE
I hate dates

### DIFF
--- a/resources/lib/item_functions.py
+++ b/resources/lib/item_functions.py
@@ -4,6 +4,7 @@ import sys
 from six.moves.urllib.parse import quote
 
 from datetime import datetime
+from dateutil import tz
 
 import xbmcgui
 
@@ -402,12 +403,17 @@ def add_gui_item(url, item_details, display_options, folder=True, default_sort=F
         end_time = datetime_from_string(item_details.program_end_date)
 
         duration = (end_time - start_time).total_seconds()
-        time_done = (datetime.now().astimezone() - start_time).total_seconds()
+        # Get current date in UTC to compare against server
+        now = datetime.utcnow()
+        now_dt = now.replace(tzinfo=tz.tzutc())
+        time_done = (now_dt - start_time).total_seconds()
         percentage_done = (float(time_done) / float(duration)) * 100.0
         capped_percentage = int(percentage_done)
 
-        start_time_string = start_time.strftime("%H:%M")
-        end_time_string = end_time.strftime("%H:%M")
+        # Convert dates to local timezone for display
+        local = tz.tzlocal()
+        start_time_string = start_time.astimezone(local).strftime("%H:%M")
+        end_time_string = end_time.astimezone(local).strftime("%H:%M")
 
         item_details.duration = int(duration)
         item_details.resume_time = int(time_done)

--- a/resources/lib/item_functions.py
+++ b/resources/lib/item_functions.py
@@ -8,7 +8,7 @@ from dateutil import tz
 
 import xbmcgui
 
-from .utils import datetime_from_string, get_art_url, image_url, kodi_version
+from .utils import datetime_from_string, get_art_url, image_url, kodi_version, get_current_datetime
 from .lazylogger import LazyLogger
 from six import ensure_text
 
@@ -403,10 +403,8 @@ def add_gui_item(url, item_details, display_options, folder=True, default_sort=F
         end_time = datetime_from_string(item_details.program_end_date)
 
         duration = (end_time - start_time).total_seconds()
-        # Get current date in UTC to compare against server
-        now = datetime.utcnow()
-        now_dt = now.replace(tzinfo=tz.tzutc())
-        time_done = (now_dt - start_time).total_seconds()
+        now = get_current_datetime()
+        time_done = (now - start_time).total_seconds()
         percentage_done = (float(time_done) / float(duration)) * 100.0
         capped_percentage = int(percentage_done)
 

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -5,7 +5,6 @@ import socket
 import json
 import time
 from datetime import datetime
-from dateutil import tz
 
 import xbmcaddon
 import xbmcgui
@@ -14,7 +13,7 @@ import xbmc
 from .kodi_utils import HomeWindow
 from .jellyfin import API
 from .lazylogger import LazyLogger
-from .utils import datetime_from_string, translate_string, save_user_details, load_user_details
+from .utils import datetime_from_string, translate_string, save_user_details, load_user_details, get_current_datetime
 from .dialogs import QuickConnectDialog
 
 log = LazyLogger(__name__)
@@ -369,10 +368,7 @@ def create_user_listitem(server, user):
     Create a user listitem for the user selection screen
     '''
     config = user.get("Configuration")
-    # Get current time in UTC
-    now = datetime.utcnow()
-    utc = tz.tzutc()
-    now_dt = now.replace(tzinfo=utc)
+    now = get_current_datetime()
     if config is not None:
         name = user.get("Name")
         time_ago = ""
@@ -380,7 +376,7 @@ def create_user_listitem(server, user):
         # Calculate how long it's been since the user was last active
         if last_active:
             last_active_date = datetime_from_string(last_active)
-            ago = now_dt - last_active_date
+            ago = now - last_active_date
             # Check days
             if ago.days > 0:
                 time_ago += ' {}d'.format(ago.days)

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -5,6 +5,7 @@ import socket
 import json
 import time
 from datetime import datetime
+from dateutil import tz
 
 import xbmcaddon
 import xbmcgui
@@ -368,6 +369,10 @@ def create_user_listitem(server, user):
     Create a user listitem for the user selection screen
     '''
     config = user.get("Configuration")
+    # Get current time in UTC
+    now = datetime.utcnow()
+    utc = tz.tzutc()
+    now_dt = now.replace(tzinfo=utc)
     if config is not None:
         name = user.get("Name")
         time_ago = ""
@@ -375,7 +380,7 @@ def create_user_listitem(server, user):
         # Calculate how long it's been since the user was last active
         if last_active:
             last_active_date = datetime_from_string(last_active)
-            ago = datetime.now().astimezone() - last_active_date
+            ago = now_dt - last_active_date
             # Check days
             if ago.days > 0:
                 time_ago += ' {}d'.format(ago.days)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -104,14 +104,11 @@ def datetime_from_string(time_string):
         # https://bugs.python.org/issue27400
         dt = datetime(*(time.strptime(time_string, "%Y-%m-%dT%H:%M:%S.%f %Z")[0:6]))
 
-    # Convert server dates from UTC to local time
+    # Dates received from the server are in UTC, but parsing them results in naive objects
     utc = tz.tzutc()
-    local = tz.tzlocal()
-
     utc_dt = dt.replace(tzinfo=utc)
-    local_dt = utc_dt.astimezone(local)
 
-    return local_dt
+    return utc_dt
 
 
 def convert_size(size_bytes):

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -111,6 +111,15 @@ def datetime_from_string(time_string):
     return utc_dt
 
 
+def get_current_datetime():
+    # Get current time in UTC
+    now = datetime.utcnow()
+    utc = tz.tzutc()
+    now_dt = now.replace(tzinfo=utc)
+
+    return now_dt
+
+
 def convert_size(size_bytes):
     if size_bytes == 0:
         return "0B"


### PR DESCRIPTION
Switches all date comparisons to UTC, explicitly setting the timezone.  Only convert them to local timezone when the date is going to be displayed to the user (in the live tv - programs menu)

Fixes #171 