### PR TITLE
Download all external subs when playback starts

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -15,7 +15,7 @@ from six.moves.urllib.parse import urlencode
 from .jellyfin import api
 from .lazylogger import LazyLogger
 from .dialogs import ResumeDialog
-from .utils import send_event_notification, convert_size, get_device_id, translate_string, load_user_details, translate_path
+from .utils import send_event_notification, convert_size, get_device_id, translate_string, load_user_details, translate_path, download_external_sub
 from .kodi_utils import HomeWindow
 from .datamanager import clear_old_cache_data
 from .item_functions import extract_item_info, add_gui_item, get_art
@@ -838,12 +838,18 @@ def external_subs(media_source, list_item, item_id):
             language = stream.get('Language', '')
             codec = stream.get('Codec', '')
 
-            url_root = '{}/Videos/{}/{}/Subtitles/{}'.format(server, item_id, source_id, index)
+            url = '{}{}'.format(server, stream.get('DeliveryUrl'))
             if language:
-                url = '{}/0/Stream.{}.{}?api_key={}'.format(
-                    url_root, language, codec, token)
+                '''
+                Starting in 10.8, the server no longer provides language
+                specific download points.  We have to download the file
+                and name it with the language code ourselves so Kodi
+                will parse it correctly
+                '''
+                subtitle_file = download_external_sub(language, codec, url)
             else:
-                url = '{}/0/Stream.{}?api_key={}'.format(url_root, codec, token)
+                # If there is no language defined, we can go directly to the server
+                subtitle_file = url
 
             default = ""
             if stream['IsDefault']:
@@ -855,7 +861,7 @@ def external_subs(media_source, list_item, item_id):
             sub_name = '{} ( {} ) {} {}'.format(language, codec, default, forced)
 
             sub_names.append(sub_name)
-            externalsubs.append(url)
+            externalsubs.append(subtitle_file)
 
     if len(externalsubs) == 0:
         return

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -15,6 +15,7 @@ import time
 import math
 import os
 import hashlib
+import requests
 from datetime import datetime
 from dateutil import tz
 import re
@@ -363,3 +364,18 @@ def translate_path(path):
         return xbmcvfs.translatePath(path)
     else:
         return xbmc.translatePath(path)
+
+
+def download_external_sub(language, codec, url):
+
+    # Download the subtitle file
+    r = requests.get(url)
+    r.raise_for_status()
+
+    # Write the subtitle file to the local filesystem
+    file_name = 'Stream.{}.{}'.format(language, codec)
+    file_path = py2_decode(translate_path('special://temp/{}'.format(file_name)))
+    with open(file_path, 'wb') as f:
+        f.write(r.content)
+
+    return file_path


### PR DESCRIPTION
Fixes #175, since the server guys are jerks and broke my language specific download endpoints.

Kinda gross, since we have to download all external subs for a given video even if they're not going to be used, but trying to pass in `plugin://plugin.video.jellycon` as a subtitle endpoint won't work and gives a subtitle parser error.