### PR TITLE
Fix forced and sdh/cc/hi subtitle not working

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -845,6 +845,8 @@ def external_subs(media_source, list_item, item_id):
                 language = '%s.%s' % (language, 'default')
             if stream['IsForced']:
                 language = '%s.%s' % (language, 'forced')
+            if stream.get('Title') and stream['Title'] in ('sdh', 'cc', 'hi'):
+                language = '%s.%s' % (language, stream.get('Title'))
             codec = stream.get('Codec', '')
 
             url = '{}{}'.format(server, stream.get('DeliveryUrl'))

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -841,6 +841,10 @@ def external_subs(media_source, list_item, item_id):
             source_id = media_source['Id']
 
             language = stream.get('Language', '')
+            if stream['IsDefault']:
+                language = '%s.%s' % (language, 'default')
+            if stream['IsForced']:
+                language = '%s.%s' % (language, 'forced')
             codec = stream.get('Codec', '')
 
             url = '{}{}'.format(server, stream.get('DeliveryUrl'))
@@ -856,14 +860,7 @@ def external_subs(media_source, list_item, item_id):
                 # If there is no language defined, we can go directly to the server
                 subtitle_file = url
 
-            default = ""
-            if stream['IsDefault']:
-                default = "default"
-            forced = ""
-            if stream['IsForced']:
-                forced = "forced"
-
-            sub_name = '{} ( {} ) {} {}'.format(language, codec, default, forced)
+            sub_name = '{} ( {} )'.format(language, codec)
 
             sub_names.append(sub_name)
             externalsubs.append(subtitle_file)


### PR DESCRIPTION
**Condition:**
I have multiple subtitle
- movie_name.en.srt
- movie_name.en.forced.srt
- movie_name.en.sdh.srt
- movie_name.id.srt

**Expected:**
- I can play movie with forced subtitle, either by choosing subtitle
before play movies, or while playing movies
- I can play movie with sdh/cc/hi subtitle, either by choosing subtitle
before play movies, or while playing movies

**Result:**
- I cannot play movie with forced subtitle
- I cannot play movie with sdh/cc/hi subtitle

This happen because downloaded subtitle file only has language identifier in
it's name. It doesn't have unique identifier such as forced or sdh/cc/hi. This fix
add those unique identifier to the downloaded subtitle.

This fix doesn't handle transcode procedure.

**Reference:**
- https://kodi.wiki/view/Subtitles#Using_Forced_Subtitles