### PR TITLE
CI - remove use_aliases from emoji command

### DIFF
--- a/.github/tools/reformat_changelog.py
+++ b/.github/tools/reformat_changelog.py
@@ -23,7 +23,7 @@ class SectionType(TypedDict):
 
 def reformat(item_format: str, output_emoji: bool) -> None:
     data = [
-        emojize(x.strip(), use_aliases=True, variant="emoji_type")
+        emojize(x.strip(), variant="emoji_type")
         for x in sys.stdin.readlines()
         if x.strip()
     ]


### PR DESCRIPTION
version 2.0 of the emoji library removed the `use_aliases` keyword.

https://github.com/carpedm20/emoji/releases/tag/v2.0.0