### PR TITLE
Don't request empty folders from api if setting is disabled

### DIFF
--- a/resources/lib/dir_functions.py
+++ b/resources/lib/dir_functions.py
@@ -327,6 +327,8 @@ def process_directory(url, progress, params, use_cache_data=False):
                      '?userId={}'.format(user_id) +
                      '&Fields={}'.format(default_filters) +
                      '&format=json')
+                if not show_empty_folders:
+                    u = u + '&isMissing=False'
 
             elif item_details.item_type == "Season":
                 u = ('/Shows/' + item_details.series_id +


### PR DESCRIPTION
If the `show_empty_folders` option is disabled, exclude "missing" content from the api request to the server when getting the seasons list of a show.  Possible alternative method to #197, seems to achieve the same result while reducing local device load. @aiosk does this solve the issue?

side note: I don't like doing string addition like this, but I don't want to go through and rewrite all of them in this file in a bugfix PR.