### PR TITLE
Add Continue Watching Widget

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1099,3 +1099,8 @@ msgstr "Quick Connect"
 msgctxt "#30444"
 msgid "Login using Quick Connect"
 msgstr "Login using Quick Connect"
+
+
+msgctxt "#30445"
+msgid "Continue Watching"
+msgstr "Continue Watching"

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -553,6 +553,7 @@ def display_menu(params):
 
 def show_global_types(params):
     handle = int(sys.argv[1])
+
     user_id = get_current_user_id()
 
     continue_watching_url_params = {
@@ -569,6 +570,7 @@ def show_global_types(params):
                             "plugin://plugin.video.jellycon/?mode=SHOW_ADDON_MENU&type=global_list_movies")
     add_menu_directory_item(translate_string(30261),
                             "plugin://plugin.video.jellycon/?mode=SHOW_ADDON_MENU&type=global_list_tvshows")
+
     xbmcplugin.endOfDirectory(handle)
 
 

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -553,12 +553,22 @@ def display_menu(params):
 
 def show_global_types(params):
     handle = int(sys.argv[1])
+    user_id = get_current_user_id()
+
+    continue_watching_url_params = {
+        "Fields": get_default_filters(),
+        "ImageTypeLimit": 1,
+    }
+    continue_watching_url = get_jellyfin_url("/Users/{}/Items/Resume".format(user_id), continue_watching_url_params)
+    add_menu_directory_item(translate_string(30445),
+                            "plugin://plugin.video.jellycon/?mode=GET_CONTENT&url=" + quote(continue_watching_url) +
+                            "&media_type=movies" +
+                            "&name_format="+quote("Episode|episode_name_format"))
 
     add_menu_directory_item(translate_string(30256),
                             "plugin://plugin.video.jellycon/?mode=SHOW_ADDON_MENU&type=global_list_movies")
     add_menu_directory_item(translate_string(30261),
                             "plugin://plugin.video.jellycon/?mode=SHOW_ADDON_MENU&type=global_list_tvshows")
-
     xbmcplugin.endOfDirectory(handle)
 
 


### PR DESCRIPTION
My attempt to solve https://github.com/jellyfin/jellycon/issues/19

i'm using https://api.jellyfin.org/#operation/GetResumeItems to get continue watching list

it would be nice if this feature could make it way to `Custom Widgets` too