### PR TITLE
Apply watched status to the correct user

### DIFF
--- a/resources/lib/jellyfin.py
+++ b/resources/lib/jellyfin.py
@@ -25,8 +25,8 @@ class API:
         self.verify_cert = settings.getSetting('verify_cert') == 'true'
 
     def get(self, path):
-        if 'x-mediabrowser-token' not in self.headers:
-            self.create_headers()
+        if 'x-mediabrowser-token' not in self.headers or self.token not in self.headers:
+            self.create_headers(True)
 
         # Fixes initial login where class is initialized before wizard completes
         if not self.server:
@@ -53,8 +53,8 @@ class API:
         return response_data
 
     def post(self, url, payload={}):
-        if 'x-mediabrowser-token' not in self.headers:
-            self.create_headers()
+        if 'x-mediabrowser-token' not in self.headers or self.token not in self.headers:
+            self.create_headers(True)
 
         url = '{}{}'.format(self.server, url)
 
@@ -70,8 +70,8 @@ class API:
         return response_data
 
     def delete(self, url):
-        if 'x-mediabrowser-token' not in self.headers:
-            self.create_headers()
+        if 'x-mediabrowser-token' not in self.headers or self.token not in self.headers:
+            self.create_headers(True)
 
         url = '{}{}'.format(self.server, url)
 

--- a/service.py
+++ b/service.py
@@ -29,7 +29,7 @@ if log_timing_data:
 
 # clear user and token when logging in
 home_window = HomeWindow()
-home_window.clear_property("userid")
+home_window.clear_property("user_name")
 home_window.clear_property("AccessToken")
 home_window.clear_property("Params")
 
@@ -99,7 +99,7 @@ if enable_logging:
                                   time=8000,
                                   icon=xbmcgui.NOTIFICATION_WARNING)
 
-prev_user_id = home_window.get_property("userid")
+prev_user = home_window.get_property("user_name")
 first_run = True
 home_window.set_property('exit', 'False')
 
@@ -118,9 +118,9 @@ while home_window.get_property('exit') == 'False':
 
             if not screen_saver_active:
                 user_changed = False
-                if prev_user_id != home_window.get_property("userid"):
+                if prev_user != home_window.get_property("user_name"):
                     log.debug("user_change_detected")
-                    prev_user_id = home_window.get_property("userid")
+                    prev_user = home_window.get_property("user_name")
                     user_changed = True
 
                 if user_changed or first_run:
@@ -186,7 +186,7 @@ if context_monitor:
     context_monitor.stop_monitor()
 
 # clear user and token when loggin off
-home_window.clear_property("userid")
+home_window.clear_property("user_name")
 home_window.clear_property("AccessToken")
 home_window.clear_property("userimage")
 


### PR DESCRIPTION
Fixes #209.  Another side effect where requests were using the wrong metadata and applying watched status to the previously selected user.