### PR TITLE
Make it clear that the play next episode setting is in seconds

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1077,8 +1077,8 @@ msgid "Play cinema intros"
 msgstr "Play cinema intros"
 
 msgctxt "#30439"
-msgid "Show play next episode at time left"
-msgstr "Show play next episode at time left"
+msgid "Show play next episode at time left in seconds"
+msgstr "Show play next episode at time left in seconds"
 
 msgctxt "#30440"
 msgid "Play next"


### PR DESCRIPTION
This setting didn't have any units, so it was unclear if it was in seconds or minutes