### PR TITLE
subtitle not working on self sign certificate

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -374,9 +374,11 @@ def translate_path(path):
 
 
 def download_external_sub(language, codec, url):
+    addon_settings = xbmcaddon.Addon()
+    verify_cert = addon_settings.getSetting('verify_cert') == 'true'
 
     # Download the subtitle file
-    r = requests.get(url)
+    r = requests.get(url, verify=verify_cert)
     r.raise_for_status()
 
     # Write the subtitle file to the local filesystem


### PR DESCRIPTION
`requests.get` when download subtitle file do not respect "Verify HTTPS certificate" setting.

STEPS TO REPRODUCE:
- i have installed self sign certificate on jellyfin server
- i have set "Verify HTTPS certificate" to false on addon setting

EXPECTED RESULTS:
i can play movies

ACTUAL RESULTS:
i can not play movies.

this happened because `requests.get` when download subtitle file do not respect "Verify HTTPS certificate" setting.

this PR add "Verify HTTPS certificate" setting when downloading subtitle file