### PR TITLE
add shuffle play on seasons item

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1108,3 +1108,7 @@ msgstr "Continue Watching"
 msgctxt "#30446"
 msgid "There was an error logging in"
 msgstr "There was an error logging in"
+
+msgctxt "#30447"
+msgid "Shuffle"
+msgstr "Shuffle"

--- a/resources/lib/dir_functions.py
+++ b/resources/lib/dir_functions.py
@@ -404,6 +404,7 @@ def process_directory(url, progress, params, use_cache_data=False):
         item_details = ItemDetails()
 
         item_details.id = first_season_item.id
+        item_details.series_id = first_season_item.series_id
         item_details.name = translate_string(30290)
         item_details.art = first_season_item.art
         item_details.play_count = played

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -353,6 +353,11 @@ def show_menu(params):
         li.setProperty('menu_id', 'play_all')
         action_items.append(li)
 
+    if result["Type"] == "Season":
+        li = xbmcgui.ListItem(translate_string(30447), offscreen=True)
+        li.setProperty('menu_id', 'shuffle')
+        action_items.append(li)
+
     if result["Type"] in ["Episode", "Movie", "Video", "TvChannel", "Program", "MusicVideo"]:
         li = xbmcgui.ListItem(translate_string(30275), offscreen=True)
         li.setProperty('menu_id', 'transcode')
@@ -497,6 +502,10 @@ def show_menu(params):
         xbmc.executebuiltin("Container.Refresh")
 
     elif selected_action == "play_all":
+        play_action(params)
+
+    elif selected_action == "shuffle":
+        params["action"] = "shuffle"
         play_action(params)
 
     elif selected_action == "play_trailer":
@@ -839,6 +848,8 @@ def play_action(params):
     play_info = {}
     play_info["action"] = action
     play_info["item_id"] = item_id
+    play_info["series_id"] = params.get("series_id")
+    play_info["item_name"] = params.get("item_name")
     play_info["auto_resume"] = str(auto_resume)
     play_info["force_transcode"] = force_transcode
     play_info["media_source_id"] = media_source_id

--- a/resources/lib/item_functions.py
+++ b/resources/lib/item_functions.py
@@ -456,6 +456,9 @@ def add_gui_item(url, item_details, display_options, folder=True, default_sort=F
     if item_details.series_id:
         item_properties["series_id"] = item_details.series_id
 
+    if item_details.name:
+        item_properties["name"] = item_details.name
+
     # new way
     info_labels = {}
 

--- a/resources/lib/monitors.py
+++ b/resources/lib/monitors.py
@@ -19,6 +19,8 @@ class ContextMonitor(threading.Thread):
     def run(self):
 
         item_id = None
+        series_id = None
+        item_name = None
         log.debug("ContextMonitor Thread Started")
 
         while not xbmc.Monitor().abortRequested() and not self.stop_thread:
@@ -31,10 +33,14 @@ class ContextMonitor(threading.Thread):
                         xbmc.executebuiltin("Dialog.Close(contextmenu,true)")
                         params = {}
                         params["item_id"] = item_id
+                        params["series_id"] = series_id
+                        params["item_name"] = item_name
                         show_menu(params)
 
                 container_id = xbmc.getInfoLabel("System.CurrentControlID")
                 item_id = xbmc.getInfoLabel("Container(" + str(container_id) + ").ListItem.Property(id)")
+                series_id = xbmc.getInfoLabel("Container(" + str(container_id) + ").ListItem.Property(series_id)")
+                item_name = xbmc.getInfoLabel("Container(" + str(container_id) + ").ListItem.Property(name)")
 
                 xbmc.sleep(100)
 

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -268,13 +268,14 @@ def play_file(play_info):
             'Recursive': True
         }
 
-        if action == "shuffle":
+        if result.get("Type") == "Season":
+            url_params["ExcludeLocationTypes"] = "Virtual"
+            url_params["Limit"] = item_limit
             if play_info.get("item_name") == translate_string(30290):
                 url_params["ParentId"] = play_info.get("series_id")
-            url_params["Filters"] = "IsNotFolder"
-            url_params["ExcludeLocationTypes"] = "Virtual"
+
+        if action == "shuffle":
             url_params["SortBy"] = "Random"
-            url_params["Limit"] = item_limit
 
         url = get_jellyfin_url(url_root, url_params)
         result = api.get(url)

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -244,6 +244,7 @@ def play_file(play_info):
     force_auto_resume = settings.getSetting('forceAutoResume') == 'true'
     jump_back_amount = int(settings.getSetting("jump_back_amount"))
     play_cinema_intros = settings.getSetting('play_cinema_intros') == 'true'
+    item_limit = settings.getSetting("show_x_filtered_items")
 
     server = settings.getSetting('server_address')
 
@@ -266,6 +267,14 @@ def play_file(play_info):
             'IncludeItemTypes': 'Episode,Audio',
             'Recursive': True
         }
+
+        if action == "shuffle":
+            if play_info.get("item_name") == translate_string(30290):
+                url_params["ParentId"] = play_info.get("series_id")
+            url_params["Filters"] = "IsNotFolder"
+            url_params["ExcludeLocationTypes"] = "Virtual"
+            url_params["SortBy"] = "Random"
+            url_params["Limit"] = item_limit
 
         url = get_jellyfin_url(url_root, url_params)
         result = api.get(url)


### PR DESCRIPTION
**Steps:**
- Go to List of TV Shows with either one of:
  - `Jellyfin Libraries` > `Shows`
  - `Global Lists` > `TV Shows`
- Open one of Tv Show
- Select `All` or `Season *`. Open Context Menu

**Expected:**
There is menu to shuffle play so i can shuffle play on season item, including `All` season item

**Actual:**
no menu to shuffle play

**Known Issue**
Shuffle play only working properly on `All` season item.

Shuffle play on `Season *` item not working properly because of https://github.com/jellyfin/jellyfin/issues/4402 & https://github.com/jellyfin/jellyfin/issues/6390.
It might be working after https://github.com/jellyfin/jellyfin/pull/8678 though.

---

**Steps:**
- Go to list of TV Shows with either one of:
  - `Jellyfin Libraries` > `Shows`
  - `Global Lists` > `TV Shows`
- Open one of Tv Show
- Select `All` or `Season *`. Open Context Menu

**Expected:**
i can `Play All` on all season item, including `All` season item

**Actual:**
Error NoCompatibleStream