### PR TITLE
Add instant mix and shuffle features for music

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1108,3 +1108,15 @@ msgstr "Continue Watching"
 msgctxt "#30446"
 msgid "There was an error logging in"
 msgstr "There was an error logging in"
+
+msgctxt "#30447"
+msgid "Max Play Queue Size"
+msgstr "Max Play Queue Size"
+
+msgctxt "#30448"
+msgid "Shuffle"
+msgstr "Shuffle"
+
+msgctxt "#30449"
+msgid "Instant Mix"
+msgstr "Instant Mix"

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -343,6 +343,7 @@ def show_menu(params):
 
     action_items = []
 
+    # Additional items to include in the context menu for different item types
     if result["Type"] in ["Episode", "Movie", "Music", "Video", "Audio", "TvChannel", "Program", "MusicVideo"]:
         li = xbmcgui.ListItem(translate_string(30314), offscreen=True)
         li.setProperty('menu_id', 'play')
@@ -352,6 +353,17 @@ def show_menu(params):
         li = xbmcgui.ListItem(translate_string(30317), offscreen=True)
         li.setProperty('menu_id', 'play_all')
         action_items.append(li)
+
+    if result["Type"] in ["MusicArtist", "MusicAlbum", "Playlist", "Series", "Season"]:
+        li = xbmcgui.ListItem(translate_string(30448), offscreen=True)
+        li.setProperty('menu_id', 'shuffle')
+        action_items.append(li)
+
+    if result["Type"] in ["MusicArtist", "MusicAlbum", "Audio"]:
+        li = xbmcgui.ListItem(translate_string(30449), offscreen=True)
+        li.setProperty('menu_id', 'instant_mix')
+        action_items.append(li)
+
 
     if result["Type"] in ["Episode", "Movie", "Video", "TvChannel", "Program", "MusicVideo"]:
         li = xbmcgui.ListItem(translate_string(30275), offscreen=True)
@@ -497,6 +509,14 @@ def show_menu(params):
         xbmc.executebuiltin("Container.Refresh")
 
     elif selected_action == "play_all":
+        play_action(params)
+
+    elif selected_action == "shuffle":
+        params["action"] = "shuffle"
+        play_action(params)
+
+    elif selected_action == "instant_mix":
+        params["action"] = "instant_mix"
         play_action(params)
 
     elif selected_action == "play_trailer":

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -44,6 +44,7 @@
 		<setting id="audio_codec" type="select" label="30419" values="ac3|aac" default="ac3"/>
 		<setting id="audio_playback_bitrate" type="select" label="30418" values="128|160|192|256|320|384|448|640" default="256" visible="true"/>
 		<setting id="audio_max_channels" type="slider" label="30420" default="8" range="2,1,8" option="int" visible="true"/>
+                <setting id="max_play_queue" type="slider" label="30447" default="100" range="20, 10, 1000" option="int" visible="true"/>
 
 	</category>
 	<category label="30214">


### PR DESCRIPTION
More improvements for #128 

* Adds ability to start an Instant Mix from a song, album, or artist
* Adds ability to shuffle play an artist/album
* Fixes playback order when selecting "Play All" on an item
* Implement a max queue size.  Useful for low power devices and large music collections.