### PR TITLE
Increase maximum stream bitrate

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -17,7 +17,7 @@ import sys
 from .jellyfin import api
 from .lazylogger import LazyLogger
 from .dialogs import ResumeDialog
-from .utils import send_event_notification, convert_size, get_device_id, translate_string, load_user_details, translate_path, get_jellyfin_url, download_external_sub
+from .utils import send_event_notification, convert_size, get_device_id, translate_string, load_user_details, translate_path, get_jellyfin_url, download_external_sub, get_bitrate
 from .kodi_utils import HomeWindow
 from .datamanager import clear_old_cache_data
 from .item_functions import extract_item_info, add_gui_item, get_art
@@ -1224,8 +1224,7 @@ def get_play_url(media_source, play_session_id, channel_id=None):
 
         user_details = load_user_details()
         user_token = user_details.get('token')
-        playback_bitrate = settings.getSetting("force_max_stream_bitrate")
-        bitrate = int(playback_bitrate) * 1000
+        bitrate = get_bitrate(settings.getSetting("force_max_stream_bitrate"))
         playback_max_width = settings.getSetting("playback_max_width")
         audio_codec = settings.getSetting("audio_codec")
         audio_playback_bitrate = settings.getSetting("audio_playback_bitrate")
@@ -1484,17 +1483,16 @@ def get_item_playback_info(item_id, force_transcode):
     if settings.getSetting("force_transcode_mpeg4") == "true":
         filtered_codecs.append("mpeg4")
 
-    playback_bitrate = settings.getSetting("max_stream_bitrate")
-    force_playback_bitrate = settings.getSetting("force_max_stream_bitrate")
-    if force_transcode:
-        playback_bitrate = force_playback_bitrate
+    if not force_transcode:
+        bitrate = get_bitrate(settings.getSetting("max_stream_bitrate"))
+    else:
+        bitrate = get_bitrate(settings.getSetting("force_max_stream_bitrate"))
 
     audio_codec = settings.getSetting("audio_codec")
     audio_playback_bitrate = settings.getSetting("audio_playback_bitrate")
     audio_max_channels = settings.getSetting("audio_max_channels")
 
     audio_bitrate = int(audio_playback_bitrate) * 1000
-    bitrate = int(playback_bitrate) * 1000
 
     profile = {
         "Name": "Kodi",

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -419,3 +419,13 @@ def download_external_sub(language, codec, url):
         f.write(r.content)
 
     return file_path
+
+
+def get_bitrate(enum_value):
+    ''' Get the video quality based on add-on settings.
+    Max bit rate supported by server: 2147483 (max signed 32bit integer)
+    '''
+    bitrate = [500, 1000, 1500, 2000, 2500, 3000, 4000, 5000, 6000,
+        7000, 8000, 9000, 10000, 12000, 14000, 16000, 18000,
+        20000, 25000, 30000, 35000, 40000, 100000, 1000000, 2147483]
+    return bitrate[int(enum_value) if enum_value else 24] * 1000

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -28,7 +28,7 @@
 
 		<setting label="30238" type="lsep"/>
 		<setting type="sep" />
-		<setting id="max_stream_bitrate" type="slider" label="30208" default="75000" range="400,100,100000" option="int" visible="true"/>
+		<setting id="max_stream_bitrate" type="enum" label="30208" values="0.5 Mbps|1 Mbps|1.5 Mbps|2.0 Mbps|2.5 Mbps|3.0 Mbps|4.0 Mbps|5.0 Mbps|6.0 Mbps|7.0 Mbps|8.0 Mbps|9.0 Mbps|10.0 Mbps|12.0 Mbps|14.0 Mbps|16.0 Mbps|18.0 Mbps|20.0 Mbps|25.0 Mbps|30.0 Mbps|35.0 Mbps|40.0 Mbps|100.0 Mbps|1000.0 Mbps [default]|Maximum" visible="true" default="23" />
 		<setting id="allow_direct_file_play" type="bool" label="30433" default="false" visible="true" enable="true" />
 		<setting id="force_transcode_h265" type="bool" label="30236" default="false" visible="true" enable="true" />
 		<setting id="force_transcode_mpeg2" type="bool" label="30239" default="false" visible="true" enable="true" />
@@ -38,7 +38,7 @@
 
 		<setting label="30211" type="lsep"/>
 		<setting type="sep" />
-		<setting id="force_max_stream_bitrate" type="slider" label="30434" default="7000" range="400,100,15000" option="int" visible="true"/>
+		<setting id="force_max_stream_bitrate" type="enum" label="30434" values="0.5 Mbps|1 Mbps|1.5 Mbps|2.0 Mbps|2.5 Mbps|3.0 Mbps|4.0 Mbps|5.0 Mbps|6.0 Mbps|7.0 Mbps [default]|8.0 Mbps|9.0 Mbps|10.0 Mbps|12.0 Mbps|14.0 Mbps|16.0 Mbps|18.0 Mbps|20.0 Mbps|25.0 Mbps|30.0 Mbps|35.0 Mbps|40.0 Mbps|100.0 Mbps|1000.0 Mbps|Maximum" visible="true" default="9" />
 		<setting id="playback_max_width" type="select" label="30212" values="640|720|1024|1280|1440|1600|1920|2600|4096" default="1920" visible="true"/>
 		<setting id="playback_video_force_8" type="bool" label="30213" default="false" visible="true" enable="true"/>
 		<setting id="audio_codec" type="select" label="30419" values="ac3|aac" default="ac3"/>


### PR DESCRIPTION
Use enum for setting max bitrate, same as in jellyfin-kodi. New default is 1000000.
Fixes #257
