### PR TITLE
pep8 refactor - part 1

### DIFF
--- a/resources/lib/loghandler.py
+++ b/resources/lib/loghandler.py
@@ -42,7 +42,9 @@ class LogHandler(logging.StreamHandler):
             string = self.format(record)
 
             # Hide server URL in logs
-            string = string.replace(self.server or "{server}", "{jellyfin-server}")
+            string = string.replace(
+                self.server or "{server}", "{jellyfin-server}"
+            )
 
             py_version = sys.version_info.major
             # Log level notation changed in Kodi v19
@@ -70,12 +72,17 @@ class LogHandler(logging.StreamHandler):
 
 class MyFormatter(logging.Formatter):
 
-    def __init__(self, fmt='%(name)s -> %(levelname)s::%(relpath)s:%(lineno)s %(message)s'):
+    def __init__(
+        self,
+        fmt='%(name)s -> %(levelname)s::%(relpath)s:%(lineno)s %(message)s'
+    ):
         logging.Formatter.__init__(self, fmt)
 
     def format(self, record):
         if record.pathname:
-            record.pathname = ensure_text(record.pathname, get_filesystem_encoding())
+            record.pathname = ensure_text(
+                record.pathname, get_filesystem_encoding()
+            )
 
         self._gen_rel_path(record)
 
@@ -92,7 +99,10 @@ class MyFormatter(logging.Formatter):
             o = ensure_text(o, get_filesystem_encoding())
 
             if o.startswith('  File "'):
-                # If this split can't handle your file names, you should seriously consider renaming your files.
+                """
+                If this split can't handle your file names,
+                you should seriously consider renaming your files.
+                """
                 fn = o.split('  File "', 2)[1].split('", line ', 1)[0]
                 rfn = os.path.realpath(fn)
                 if rfn.startswith(_pluginpath_real):

--- a/resources/lib/monitors.py
+++ b/resources/lib/monitors.py
@@ -26,7 +26,11 @@ class ContextMonitor(threading.Thread):
 
         while not xbmc.Monitor().abortRequested() and not self.stop_thread:
 
-            if xbmc.getCondVisibility("Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)"):
+            visibility_check = (
+                "Window.IsActive(fullscreenvideo) | "
+                "Window.IsActive(visualisation)"
+            )
+            if xbmc.getCondVisibility(visibility_check):
                 xbmc.sleep(1000)
             else:
                 if xbmc.getCondVisibility("Window.IsVisible(contextmenu)"):
@@ -37,7 +41,9 @@ class ContextMonitor(threading.Thread):
                         show_menu(params)
 
                 container_id = xbmc.getInfoLabel("System.CurrentControlID")
-                item_id = xbmc.getInfoLabel("Container(" + str(container_id) + ").ListItem.Property(id)")
+                item_id = xbmc.getInfoLabel(
+                    "Container({}).ListItem.Property(id)".format(container_id)
+                )
 
                 xbmc.sleep(100)
 

--- a/resources/lib/server_sessions.py
+++ b/resources/lib/server_sessions.py
@@ -50,10 +50,10 @@ def show_server_sessions():
         now_playing = session.get("NowPlayingItem", None)
         transcoding_info = session.get("TranscodingInfo", None)
 
-        session_info = user_name + " - " + client_name
+        session_info = "{} - {}".format(user_name, client_name)
         user_session_details = ""
 
-        percenatge_played = 0
+        percentage_played = 0
         position_ticks = 0
         runtime = 0
         play_method = "na"
@@ -68,37 +68,50 @@ def show_server_sessions():
 
             runtime = now_playing.get("RunTimeTicks", 0)
             if position_ticks > 0 and runtime > 0:
-                percenatge_played = (position_ticks / float(runtime)) * 100.0
-                percenatge_played = int(percenatge_played)
+                percentage_played = (position_ticks / float(runtime)) * 100.0
+                percentage_played = int(percentage_played)
 
-            session_info += " (" + now_playing.get("Name", "na") + " " + str(percenatge_played) + "%)"
-            user_session_details += now_playing.get("Name", "na") + " " + str(percenatge_played) + "%" + "\n"
+            session_info += " {} {}%".format(
+                now_playing.get("Name", "na"), percentage_played
+            )
+            user_session_details += "{} {}%\n".format(
+                now_playing.get("Name", "na"), percentage_played
+            )
 
         else:
             session_info += " (idle)"
-            user_session_details += "Idle" + "\n"
+            user_session_details += "Idle\n"
 
         transcoding_details = ""
         if transcoding_info:
             if not transcoding_info.get("IsVideoDirect", None):
-                transcoding_details += "Video:" + transcoding_info.get("VideoCodec", "") + ":" + str(transcoding_info.get("Width", 0)) + "x" + str(transcoding_info.get("Height", 0)) + "\n"
+                transcoding_details += "Video:{}:{}x{}\n".format(
+                    transcoding_info.get("VideoCodec", ""),
+                    transcoding_info.get("Width", 0),
+                    transcoding_info.get("Height", 0)
+                )
             else:
                 transcoding_details += "Video:direct\n"
 
             if not transcoding_info.get("IsAudioDirect", None):
-                transcoding_details += "Audio:" + transcoding_info.get("AudioCodec", "") + ":" + str(transcoding_info.get("AudioChannels", 0)) + "\n"
+                transcoding_details += "Audio:{}:{}\n".format(
+                    transcoding_info.get("AudioCodec", ""),
+                    transcoding_info.get("AudioChannels", 0)
+                )
             else:
                 transcoding_details += "Audio:direct\n"
 
-            transcoding_details += "Bitrate:" + str(transcoding_info.get("Bitrate", 0)) + "\n"
+            transcoding_details += "Bitrate:{}\n".format(
+                transcoding_info.get("Bitrate", 0)
+            )
 
         list_item = xbmcgui.ListItem(label=session_info)
         list_item.setArt(art)
 
-        user_session_details += device_name + "(" + client_version + ")\n"
-        user_session_details += client_name + "\n"
-        user_session_details += play_method + "\n"
-        user_session_details += transcoding_details + "\n"
+        user_session_details += "{}({})\n".format(device_name, client_version)
+        user_session_details += "{}\n".format(client_name)
+        user_session_details += "{}\n".format(play_method)
+        user_session_details += "{}\n".format(transcoding_details)
 
         info_labels = {}
         info_labels["duration"] = str(runtime / 10000000)
@@ -108,7 +121,7 @@ def show_server_sessions():
 
         list_item.setProperty('TotalTime', str(runtime / 10000000))
         list_item.setProperty('ResumeTime', str(position_ticks / 10000000))
-        list_item.setProperty("complete_percentage", str(percenatge_played))
+        list_item.setProperty("complete_percentage", str(percentage_played))
 
         item_tuple = ("", list_item, False)
         list_items.append(item_tuple)

--- a/resources/lib/skin_cloner.py
+++ b/resources/lib/skin_cloner.py
@@ -20,9 +20,11 @@ def clone_default_skin():
     xbmc.executebuiltin("Dialog.Close(all,true)")
     xbmc.executebuiltin("ActivateWindow(Home)")
 
-    response = xbmcgui.Dialog().yesno("JellyCon Skin Cloner",
-                                      "This will clone the default Estuary Kodi skin and add JellyCon functionality to it.",
-                                      "Do you want to continue?")
+    response = xbmcgui.Dialog().yesno(
+        "JellyCon Skin Cloner",
+        ("This will clone the default Estuary Kodi skin and"
+         "add JellyCon functionality to it."),
+        "Do you want to continue?")
     if not response:
         return
 
@@ -63,7 +65,9 @@ def clone_skin():
         log.debug("Found Path: {0}".format(found))
 
     kodi_home_path = translate_path("special://home")
-    kodi_skin_destination = os.path.join(kodi_home_path, "addons", "skin.estuary_jellycon")
+    kodi_skin_destination = os.path.join(
+        kodi_home_path, "addons", "skin.estuary_jellycon"
+    )
     log.debug("Kodi Skin Destination: {0}".format(kodi_skin_destination))
 
     # copy all skin files (clone)
@@ -71,7 +75,7 @@ def clone_skin():
     total = len(all_files)
     for skin_file in all_files:
         percentage_done = int(float(count) / float(total) * 100.0)
-        pdialog.update(percentage_done, "%s" % skin_file)
+        pdialog.update(percentage_done, skin_file)
 
         source = os.path.join(kodi_skin_source, skin_file)
         destination = os.path.join(kodi_skin_destination, skin_file)
@@ -90,7 +94,9 @@ def clone_skin():
     addon_tree.write(addon_xml_path)
 
     # get jellycon path
-    jellycon_path = os.path.join(kodi_home_path, "addons", "plugin.video.jellycon")
+    jellycon_path = os.path.join(
+        kodi_home_path, "addons", "plugin.video.jellycon"
+    )
 
     log.debug("Major Version: {0}".format(kodi_version()))
 
@@ -102,7 +108,10 @@ def clone_skin():
 
     # Copy customized skin files from our addon into cloned skin
     for file_name in file_list:
-        source = os.path.join(jellycon_path, "resources", "skins", "skin.estuary", str(kodi_version), "xml", file_name)
+        source = os.path.join(
+            jellycon_path, "resources", "skins", "skin.estuary",
+            str(kodi_version), "xml", file_name
+        )
         destination = os.path.join(kodi_skin_destination, "xml", file_name)
         xbmcvfs.copy(source, destination)
 
@@ -111,7 +120,10 @@ def clone_skin():
     pdialog.close()
     del pdialog
 
-    response = xbmcgui.Dialog().yesno("JellyCon Skin Cloner", "Do you want to switch to the new cloned skin?")
+    response = xbmcgui.Dialog().yesno(
+        "JellyCon Skin Cloner",
+        "Do you want to switch to the new cloned skin?"
+    )
     if not response:
         return
 
@@ -122,10 +134,14 @@ def clone_skin():
     result = JsonRpc('Addons.SetAddonEnabled').execute(params)
     log.debug("Addons.SetAddonEnabled : {0}".format(result))
 
-    log.debug("SkinCloner : Current Skin : " + get_value("lookandfeel.skin"))
+    log.debug("SkinCloner : Current Skin : {}".format(
+        get_value("lookandfeel.skin"))
+    )
     set_result = set_value("lookandfeel.skin", "skin.estuary_jellycon")
     log.debug("Save Setting : lookandfeel.skin : {0}".format(set_result))
-    log.debug("SkinCloner : Current Skin : " + get_value("lookandfeel.skin"))
+    log.debug("SkinCloner : Current Skin : {}".format(
+        get_value("lookandfeel.skin"))
+    )
 
 
 def update_kodi_settings():

--- a/resources/lib/tracking.py
+++ b/resources/lib/tracking.py
@@ -30,6 +30,8 @@ def timer(func):
                 data = args[1]
             elif func.__name__ == "main_entry_point" and len(sys.argv) > 2:
                 data = sys.argv[2]
-            log.info("timing_data|{0}|{1}|{2}|{3}".format(func.__name__, started, ended, data))
+            log.info("timing_data|{0}|{1}|{2}|{3}".format(
+                func.__name__, started, ended, data)
+            )
         return value
     return wrapper

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -87,7 +87,7 @@ def send_event_notification(method, data=None, hexlify=False):
 
     if hexlify:
         # Used exclusively for the upnext plugin
-        data = ensure_text(binascii.hexlify(ensure_binary(data_str)))
+        data_str = ensure_text(binascii.hexlify(ensure_binary(data_str)))
     sender = 'plugin.video.jellycon'
     data = '"[{}]"'.format(data_str.replace('"', '\\"'))
 

--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -157,7 +157,9 @@ class WebSocketClient(threading.Thread):
 
             elif command == 'SetVolume':
                 volume = arguments['Volume']
-                xbmc.executebuiltin('SetVolume(%s[,showvolumebar])' % volume)
+                xbmc.executebuiltin(
+                    'SetVolume({}[,showvolumebar])'.format(volume)
+                )
 
             elif command == 'SetAudioStreamIndex':
                 index = int(arguments['Index'])
@@ -169,7 +171,7 @@ class WebSocketClient(threading.Thread):
 
             elif command == 'SetRepeatMode':
                 mode = arguments['RepeatMode']
-                xbmc.executebuiltin('xbmc.PlayerControl(%s)' % mode)
+                xbmc.executebuiltin('xbmc.PlayerControl({})'.format(mode))
 
         elif command == 'DisplayMessage':
 
@@ -252,7 +254,9 @@ class WebSocketClient(threading.Thread):
         else:
             server = server.replace('http://', 'ws://')
 
-        websocket_url = "%s/socket?api_key=%s&deviceId=%s" % (server, token, self.device_id)
+        websocket_url = "{}/socket?api_key={}&deviceId={}".format(
+            server, token, self.device_id
+        )
         log.debug("websocket url: {0}".format(websocket_url))
 
         self._client = websocket.WebSocketApp(

--- a/resources/lib/widgets.py
+++ b/resources/lib/widgets.py
@@ -83,8 +83,9 @@ def set_background_image(force=False):
         background_items = []
 
     if len(background_items) == 0:
-        log.debug("set_background_image: Need to load more backgrounds {0} - {1}".format(
-            len(background_items), background_current_item))
+        log.debug("Need to load more backgrounds {0} - {1}".format(
+            len(background_items), background_current_item)
+        )
 
         url_params = {}
         url_params["Recursive"] = True
@@ -112,13 +113,17 @@ def set_background_image(force=False):
                     background_items.append(item_background)
 
         log.debug("set_background_image: Loaded {0} more backgrounds".format(
-            len(background_items)))
+            len(background_items))
+        )
 
     if len(background_items) > 0:
         bg_image = background_items[background_current_item].get("image")
         label = background_items[background_current_item].get("name")
         log.debug(
-            "set_background_image: {0} - {1} - {2}".format(background_current_item, label, bg_image))
+            "set_background_image: {0} - {1} - {2}".format(
+                background_current_item, label, bg_image
+            )
+        )
 
         background_current_item += 1
         if background_current_item >= len(background_items):
@@ -177,7 +182,9 @@ def check_for_new_content():
     url_params["IncludeItemTypes"] = "Movie,Episode"
     url_params["ImageTypeLimit"] = 0
 
-    played_url = get_jellyfin_url('/Users/{}/Items'.format(user_id), url_params)
+    played_url = get_jellyfin_url(
+        '/Users/{}/Items'.format(user_id), url_params
+    )
 
     result = api.get(played_url)
     log.debug("LATEST_PLAYED_ITEM: {0}".format(result))
@@ -221,7 +228,9 @@ def get_widget_content_cast(handle, params):
     if not result:
         return
 
-    if result.get("Type", "") in ["Episode", "Season"] and params.get("auto", "true") == "true":
+    if (result.get("Type", "") in ["Episode", "Season"] and
+            params.get("auto", "true") == "true"):
+
         series_id = result.get("SeriesId")
         if series_id:
             params["id"] = series_id
@@ -242,7 +251,9 @@ def get_widget_content_cast(handle, params):
             person_thumbnail = None
             if person_tag:
                 person_thumbnail = image_url(
-                    person_id, "Primary", 0, 400, 400, person_tag, server=server)
+                    person_id, "Primary", 0, 400, 400,
+                    person_tag, server=server
+                )
 
             list_item = xbmcgui.ListItem(label=person_name, offscreen=True)
 
@@ -393,12 +404,19 @@ def get_widget_content(handle, params):
         while len(ids) < item_limit and suggested_items:
             items = suggested_items[set_id]
             log.debug(
-                "BaselineItemName : {0} - {1}".format(set_id, items.get("BaselineItemName")))
+                "BaselineItemName : {0} - {1}".format(
+                    set_id, items.get("BaselineItemName")
+                )
+            )
             items = items["Items"]
             rand = random.randint(0, len(items) - 1)
             item = items[rand]
-            if item["Type"] == "Movie" and item["Id"] not in ids and (not item["UserData"]["Played"] or not hide_watched):
+
+            if (item["Type"] == "Movie" and item["Id"] not in ids and
+                    (not item["UserData"]["Played"] or not hide_watched)):
+
                 ids.append(item["Id"])
+
             del items[rand]
             if len(items) == 0:
                 del suggested_items[set_id]
@@ -412,22 +430,23 @@ def get_widget_content(handle, params):
 
     items_url = get_jellyfin_url(url_verb, url_params)
 
-    if url_params.get('IncludeItemTypes', '') == 'Episode' or params.get('type', '') == 'nextup_episodes':
+    if (url_params.get('IncludeItemTypes', '') == 'Episode' or
+            params.get('type', '') == 'nextup_episodes'):
         params["name_format"] = "Episode|episode_name_format"
 
     list_items, detected_type, total_records = process_directory(
         items_url, None, params, use_cached_widget_data)
 
-    # Combine In Progress and Next Up Episodes, append next up after In Progress
+    # Combine In Progress and Next Up Episodes, add next up after In Progress
     if widget_type == "nextup_episodes":
         inprogress_url = get_jellyfin_url(
             inprogress_url_verb, inprogress_url_params)
 
         params["name_format"] = "Episode|episode_name_format"
-        list_items_inprogress, detected_type, total_records = process_directory(
+        inprogress, detected_type, total_records = process_directory(
             inprogress_url, None, params, use_cached_widget_data)
 
-        list_items = list_items_inprogress + list_items
+        list_items = inprogress + list_items
 
     if detected_type is not None:
         # if the media type is not set then try to use the detected type
@@ -440,7 +459,7 @@ def get_widget_content(handle, params):
             content_type = 'episodes'
         elif detected_type == "Series":
             content_type = 'tvshows'
-        elif detected_type == "Music" or detected_type == "Audio" or detected_type == "Musicalbum":
+        elif detected_type in ["Music", "Audio", "Musicalbum"]:
             content_type = 'songs'
 
         if content_type:


### PR DESCRIPTION
* Bring line lengths under 80 characters
* Standardizes on `.format()` string manipulations instead of a mixture of `.format()` and `%s`
* Fixes a few typos/mis-spellings
* Removes unused function
* Changes some long if operator chains to `if 'thing' in ['option1', 'option2', 'etc']`