### PR TITLE
Add rewatch feature to episode NextUp widget

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1132,3 +1132,15 @@ msgstr "Shuffle"
 msgctxt "#30449"
 msgid "Instant Mix"
 msgstr "Instant Mix"
+
+msgctxt "#30450"
+msgid "Next Up Rewatching"
+msgstr "Next Up Rewatching"
+
+msgctxt "#30451"
+msgid "Rewatch Days (0 = Disabled)"
+msgstr "Rewatch Days (0 = Disabled)"
+
+msgctxt "#30452"
+msgid "Combine instead of replace (might cause slow-down)"
+msgstr "Combine instead of replace (might cause slow-down)"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -95,6 +95,11 @@
 		<setting id="show_empty_folders" type="bool" label="30328" default="false" visible="true" enable="true" />
 		<setting id="hide_watched" type="bool" label="30432" default="true" visible="true" enable="true" />
 
+		<setting label="30450" type="lsep"/>
+		<setting type="sep" />
+		<setting id="rewatch_days" type="slider" label="30451" default="0" range="0,1,365" option="int" visible="true"/>
+		<setting id="rewatch_combine" type="bool" label="30452" default="false" visible="true" enable="true" />
+
 		<setting label="30223" type="lsep"/>
 		<setting type="sep" />
 		<setting id="moviePageSize" type="slider" label="30331" default="0" range="0,1,100" option="int" visible="true"/>


### PR DESCRIPTION
Adds support for [SenorSmartyPants](https://github.com/SenorSmartyPants) rewatch feature to the episode NextUp widget.
See https://github.com/jellyfin/jellyfin/pull/7253 for server side implementation.