### PR TITLE
fix shuffle on series item context menu

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -286,7 +286,7 @@ def play_file(play_info):
     *all* items in that parent.
     * Taking the max queue size setting into account
     '''
-    if result.get("Type") in ["Season", "MusicArtist", "MusicAlbum",
+    if result.get("Type") in ["Season", "Series", "MusicArtist", "MusicAlbum",
                               "Playlist", "CollectionFolder", "MusicGenre"]:
         max_queue = int(settings.getSetting('max_play_queue'))
         log.debug("PlayAllFiles for parent item id: {0}".format(item_id))


### PR DESCRIPTION
**Steps**
- Open Jellycon
- Go to shows / tvshows items, either
	- `Jellyfin Libraries` > `Shows` > `Shows - Show All`
	- `Global Lists` > `TV Shows` > `Tv Shows - Show All`
- Open `context menu` on series item, select `shuffle`

**Expected Result**
jellycon shuffle series episodes

**Actual Result**
jellycon not doing anything