### PR TITLE
feat: add simple mode for less menus

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -301,6 +301,18 @@ msgctxt "#30224"
 msgid "Interaction"
 msgstr "Interaction"
 
+msgctxt "#30225"
+msgid "Interface Mode"
+msgstr "Interface Mode"
+
+msgctxt "#30226"
+msgid "Default"
+msgstr "Default"
+
+msgctxt "#30227"
+msgid "Simple"
+msgstr "Simple"
+
 msgctxt "#30229"
 msgid "TV Shows"
 msgstr "TV Shows"

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -11,6 +11,7 @@ import xbmcaddon
 from six import ensure_binary, ensure_text
 from six.moves.urllib.parse import quote
 
+from .dir_functions import get_content
 from .jellyfin import api
 from .kodi_utils import add_menu_directory_item, HomeWindow
 from .lazylogger import LazyLogger
@@ -573,6 +574,10 @@ def display_main_menu():
     handle = int(sys.argv[1])
     xbmcplugin.setContent(handle, 'files')
 
+    if settings.getSetting("interface_mode") == "1":
+        display_library_views(None)
+        return
+
     add_menu_directory_item(translate_string(30406),
                             "plugin://plugin.video.jellycon/?mode=SHOW_ADDON_MENU&type=library")
     add_menu_directory_item(translate_string(30407),
@@ -709,6 +714,11 @@ def display_tvshow_type(menu_params, view):
     if view is not None:
         base_params["ParentId"] = view.get("Id")
     path = get_jellyfin_url("/Users/{userid}/Items", base_params)
+
+    if settings.getSetting("interface_mode") == "1":
+        get_content(path, { "media_type": "tvshows" })
+        return
+
     url = sys.argv[0] + "?url=" + quote(path) + "&mode=GET_CONTENT&media_type=tvshows"
     add_menu_directory_item(view_name + translate_string(30405), url)
 
@@ -808,6 +818,11 @@ def display_music_type(menu_params, view):
         "IncludeItemTypes": "MusicAlbum"
     }
     path = get_jellyfin_url("/Users/{userid}/Items", params)
+
+    if settings.getSetting("interface_mode") == "1":
+        get_content(path, { "media_type": "MusicAlbums" })
+        return
+
     url = sys.argv[0] + "?url=" + quote(path) + "&mode=GET_CONTENT&media_type=MusicAlbums"
     add_menu_directory_item(view_name + translate_string(30320), url)
 
@@ -976,6 +991,11 @@ def display_movies_type(menu_params, view):
 
     # All Movies
     path = get_jellyfin_url("/Users/{userid}/Items", base_params)
+
+    if settings.getSetting("interface_mode") == "1":
+        get_content(path, { "media_type": "movies" })
+        return
+
     url = sys.argv[0] + "?url=" + quote(path) + "&mode=GET_CONTENT&media_type=movies"
     add_menu_directory_item('{}{}'.format(view_name, translate_string(30405)), url)
 
@@ -1113,6 +1133,11 @@ def display_mixed_type(params, view):
     if view is not None:
         base_params["ParentId"] = view.get("Id")
     path = get_jellyfin_url("/Users/{userid}/Items", base_params)
+
+    if settings.getSetting("interface_mode") == "1":
+        get_content(path, { "media_type": "mixed" })
+        return
+
     url = sys.argv[0] + "?url=" + quote(path) + "&mode=GET_CONTENT&media_type=mixed"
     add_menu_directory_item(view_name + translate_string(30405), url)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,7 +5,7 @@
 		<setting label="30388" type="lsep"/>
 		<setting label="30011" type="action" action="RunScript(plugin.video.jellycon,0,?mode=DETECT_SERVER_USER)" option="close"/>
 		<setting id="ipaddress" type="text" label="30000" default="" visible="false" enable="false" />
-		<setting id="protocol" type="select" label="30390" lvalues="30391|30392" default="0" visible="false"/>			
+		<setting id="protocol" type="select" label="30390" lvalues="30391|30392" default="0" visible="false"/>
 		<setting id="port" type="text" label="30001" default="8096" visible="false" enable="false" />
 		<setting id="server_address" type="text" label="30000" default="" visible="true" enable="true" />
 		<setting id="verify_cert" type="bool" label="30003" default="true" visible="true" enable="true" />
@@ -103,6 +103,7 @@
 		<setting label="30224" type="lsep"/>
 		<setting type="sep" />
 		<setting id="widget_select_action" type="select" label="30026" lvalues="30313|30314" default="0" visible="true"/>
+		<setting id="interface_mode" type="select" label="30225" lvalues="30226|30227" default="0" visible="true"/>
 
 	</category>
 	<category label="30111">


### PR DESCRIPTION
Introduces a new setting called **Interface Mode**. I wasn't sure where the best place to keep it was, so I put it under **Interface** → **Interaction**.

When the **Interface Mode** is set to **Simple**, it reduces the number of menus the user sees, closely resembling the web app and Jellyfin Media Player.

When a user launches Jellyfin, they're taken straight to their libraries, and when a user accessing a library, they see all media in the library with no intermediate menus.

The only exceptions are:

* `homevideos`
* `livetv`

I do not use these myself, but reviewing the contents of these menus, these submenus might be considered valuable. Especially in the case of `livetv`, skipping the intermediate menu may impede usage?

Criticism is welcome. :+1: 

### Related

* Closes https://github.com/jellyfin/jellycon/issues/286