### PR TITLE
chore: replace use of deprecated methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ pip-log.txt
 
 # Addon files
 addon.xml
+venv/

--- a/build.py
+++ b/build.py
@@ -102,13 +102,13 @@ def folder_filter(folder_name: str) -> bool:
         '.mypy_cache',
         '.pytest_cache',
         '__pycache__',
+        'venv',
     ]
     for f in filters:
         if f in folder_name.split(os.path.sep):
             return False
 
     return True
-
 
 
 if __name__ == '__main__':

--- a/resources/lib/server_sessions.py
+++ b/resources/lib/server_sessions.py
@@ -119,8 +119,7 @@ def show_server_sessions():
         info_labels["plot"] = user_session_details
         list_item.setInfo('video', info_labels)
 
-        list_item.setProperty('TotalTime', str(runtime / 10000000))
-        list_item.setProperty('ResumeTime', str(position_ticks / 10000000))
+        list_item.getVideoInfoTag().setResumePoint(position_ticks / 10000000, runtime / 10000000)
         list_item.setProperty("complete_percentage", str(percentage_played))
 
         item_tuple = ("", list_item, False)


### PR DESCRIPTION
Updates the use of deprecated methods to what is recommended. Before these fixes, JellyCon was causing 20,000+ logs per day for deprecation.

Most changes relate to the following objects:
* [xbmcgui.ListItem](https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html)
* [xbmc.InfoTagVideo](https://xbmc.github.io/docs.kodi.tv/master/kodi-dev-kit/class_x_b_m_c_addon_1_1xbmc_1_1_info_tag_video.html)

We're now setting properties through `InfoTagVideo` instead. This uses specific getters/settings and has stricter typing.

For example, `setCast` requires a list of `xbmc.Actor`. And some rating related settings require an `int`, not a `float`. 

## User Facing Changes

* Kodi now accepts a list for more details like Studios and Countries.
    * When viewing info for a movie or show, we can see all of them, not just 1.

## Notes

This does not replace every single use of a deprecated method yet. It handles the major offenders that were creating thousands of log entries, and some easy fixes. Over time, we can hopefully address the rest of the smaller ones.

The only ones left are due to `ListItem.setInfo()` calls which should be using `InfoTagVideo`, `InfoTagMusic`, `InfoTagGame`, or `InfoTagPicture`.