### PR TITLE
fix: delete item via context menu

### DIFF
--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -252,8 +252,7 @@ def unmark_item_favorite(item_id):
 
 
 def delete(item_id):
-
-    item = api.delete("/Users/{}/Items/{}".format(api.user_id, item_id))
+    item = api.get("/Users/{}/Items/{}".format(api.user_id, item_id))
 
     item_id = item.get("Id")
     item_name = item.get("Name", "")

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -259,15 +259,16 @@ def delete(item_id):
     series_name = item.get("SeriesName", "")
     ep_number = item.get("IndexNumber", -1)
 
-    final_name = ""
+    final_name_parts = []
 
     if series_name:
-        final_name += "{} -".format(series_name)
+        final_name_parts.append(series_name)
 
     if ep_number != -1:
-        final_name += "Episode {:02d} - ".format(ep_number)
+        final_name_parts.append("Episode {:02d}".format(ep_number))
 
-    final_name += item_name
+    final_name_parts.append(item_name)
+    final_name = " - ".join(final_name_parts)
 
     if not item.get("CanDelete", False):
         xbmcgui.Dialog().ok(


### PR DESCRIPTION
It wasn't possible to delete items from the context menu in JellyCon before, due to what was seemingly a typo.

In the code, we want to fetch the information on the video first to populate an "Are you sure?" dialog to the user. However, it uses the `DELETE` HTTP method instead of `GET`, so `item` was `None` which led to an exception.

This replaced `DELETE` with `GET`, which now correctly fetched the information of the media, and follows up with the appropriate dialog. Upon pressing **Yes**, the media is correctly deleted from the media server, and the list refreshes to reflect the removed item.

On the side, I also address a formatting issue in the delete dialog, where spacing is inconsistent around hyphens.

## Related

* Closes https://github.com/jellyfin/jellycon/issues/288

## Screenshots

### Before

![](https://github.com/jellyfin/jellycon/assets/22801583/e73603cd-6674-4dae-b230-168fb9d841fa)
> Navigating a show and attempting to delete an episode. Observe how their is no space after one of the hyphens (`-`).

### After

![](https://github.com/jellyfin/jellycon/assets/22801583/ea9275f6-0253-4edf-8059-3c3e5d7c364b)
> Navigating a show and attempting to delete an episode.