### PR TITLE
chore: ignore venv in git and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,5 +221,7 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 
+venv
+
 # Addon files
 addon.xml

--- a/build.py
+++ b/build.py
@@ -102,6 +102,7 @@ def folder_filter(folder_name: str) -> bool:
         '.mypy_cache',
         '.pytest_cache',
         '__pycache__',
+        'venv',
     ]
     for f in filters:
         if f in folder_name.split(os.path.sep):


### PR DESCRIPTION
Many Python developers use [venv](https://docs.python.org/3/library/venv.html) to manage their environment. Would it be fine to commit these config changes to the repo?

## Related

* Initially part of https://github.com/jellyfin/jellycon/pull/293