### PR TITLE
Add 'Force transcode av1' setting

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -349,6 +349,10 @@ msgctxt "#30241"
 msgid "Force transcode mpeg4"
 msgstr "Force transcode mpeg4"
 
+msgctxt "#30242"
+msgid "Force transcode av1"
+msgstr "Force transcode av1"
+
 msgctxt "#30246"
 msgid "Search"
 msgstr "Search"

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -1515,6 +1515,8 @@ def get_item_playback_info(item_id, force_transcode):
         filtered_codecs.append("msmpeg4v3")
     if settings.getSetting("force_transcode_mpeg4") == "true":
         filtered_codecs.append("mpeg4")
+    if settings.getSetting("force_transcode_av1") == "true":
+        filtered_codecs.append("av1")
 
     if not force_transcode:
         bitrate = get_bitrate(settings.getSetting("max_stream_bitrate"))

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -34,6 +34,7 @@
 		<setting id="force_transcode_mpeg2" type="bool" label="30239" default="false" visible="true" enable="true" />
 		<setting id="force_transcode_msmpeg4v3" type="bool" label="30240" default="false" visible="true" enable="true" />
 		<setting id="force_transcode_mpeg4" type="bool" label="30241" default="false" visible="true" enable="true" />
+		<setting id="force_transcode_av1" type="bool" label="30242" default="false" visible="true" enable="true" />
 		<setting id="direct_stream_sub_select" type="select" label="30379" lvalues="30380|30381|30382" default="0" visible="true"/>
 
 		<setting label="30211" type="lsep"/>


### PR DESCRIPTION
This adds av1 to the list of codecs that can be set to always force transcode in the settings. I tested this on the latest stable Kodi build and it works as expected. 