### PR TITLE
Explicitly request non resumeable episodes on next up widget

### DIFF
--- a/resources/lib/widgets.py
+++ b/resources/lib/widgets.py
@@ -378,6 +378,7 @@ def get_widget_content(handle, params):
         url_params["Limit"] = item_limit
         url_params["userid"] = user_id
         url_params["Recursive"] = True
+        url_params["enableResumable"] = False
         url_params["ImageTypeLimit"] = 1
         # check if rewatching is enabled and combine is disabled
         rewatch_days = int(settings.getSetting("rewatch_days"))


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin/pull/10200 added "in progress" episodes to NextUp api query.

This change only affects jellyfin 10.9.X.

When using jellycon with jellyfin 10.9.x we now see the in progress episodes twice. 

While we can undo the work done on https://github.com/jellyfin/jellycon/pull/82 , I think its better to just pass the new parameter to NextUp query with the value of false.

This way jellycon works fine (no duplicates) on both jellyfin 10.9 and older ones. 



