### PR TITLE
New Tv Shows menu entry , Totally unwatched Tv Shows entries

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1152,3 +1152,7 @@ msgstr "Combine instead of replace (might cause slow-down)"
 msgctxt "#30453"
 msgid "Hide number of items to show on entry title"
 msgstr "Hide number of items to show on entry title"
+
+msgctxt "#30454"
+msgid " - Totally Unwatched"
+msgstr " - Totally Unwatched"

--- a/resources/lib/dir_functions.py
+++ b/resources/lib/dir_functions.py
@@ -302,9 +302,10 @@ def process_directory(url, progress, params, use_cache_data=False):
 
     detected_type = None
     dir_items = []
-
+    OnlyTotallyUnwatchedTvShow = params.get("OnlyTotallyUnwatchedTvShow", None)    
     for item_details in item_list:
-
+        if OnlyTotallyUnwatchedTvShow == "1" and item_details.watched_episodes > 0:
+            continue
         item_details.total_items = item_count
 
         if progress is not None:

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -738,6 +738,14 @@ def display_tvshow_type(menu_params, view):
     url = sys.argv[0] + "?url=" + quote(path) + "&mode=GET_CONTENT&media_type=tvshows"
     add_menu_directory_item(view_name + translate_string(30285), url)
 
+    # Totally unwatched tv shows
+    params = {}
+    params.update(base_params)
+    params["IsPlayed"] = False       
+    path = get_jellyfin_url("/Users/{userid}/Items", params)
+    url = sys.argv[0] + "?url=" + quote(path) + "&mode=GET_CONTENT&media_type=tvshows&OnlyTotallyUnwatchedTvShow=1"
+    add_menu_directory_item(view_name + translate_string(30454), url)
+
     # In progress episodes
     params = {}
     params.update(base_params)


### PR DESCRIPTION
This new view helps on cases such as 

For example, We have 20 tv shows on our jellyfin setup.

4 are totally watched (all episodes are marked as watched)
6 are partially watched (some episodes of the shows are watched and some are not)
10 we never watched any episodes , all episodes are not watched.

This PR add the option to see only the 10 shows we never watched named "Tv Shows - Totally Unwatched".

The existing menu named "TV Shows - Unwatched" will show 16 shows (both partially watched and unwatched)
