### PR TITLE
Remove py2 from testing CI

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,22 +30,9 @@ jobs:
           queries: +security-and-quality
 
       - name: Set up Python
-        if: matrix.version != '2.7'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
-
-      - name: Set up Python 2.7
-        if: matrix.version == '2.7'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            python2.7 python2.7-dev python2-pip-whl
-          sudo ln -sf python2.7 /usr/bin/python
-          export PYTHONPATH=`echo /usr/share/python-wheels/pip-*py2*.whl`
-          sudo --preserve-env=PYTHONPATH python -m pip install --upgrade pip setuptools wheel
-          sudo chown -R $USER /usr/local/lib/python2.7
-
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'python' ]
-        version: ['2.7', '3.9']
+        version: ['3.9']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,27 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_version: ['2.7', '3.9']
+        py_version: ['3.9']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.py_version }}
-        if: matrix.py_version != '2.7'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py_version }}
-
-      - name: Set up Python 2.7
-        if: matrix.py_version == '2.7'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            python2.7 python2.7-dev python2-pip-whl
-          sudo ln -sf python2.7 /usr/bin/python
-          export PYTHONPATH=`echo /usr/share/python-wheels/pip-*py2*.whl`
-          sudo --preserve-env=PYTHONPATH python -m pip install --upgrade pip setuptools wheel
-          sudo chown -R $USER /usr/local/lib/python2.7
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Python 2 testing has been broken for a while, and is old and horrible anyway.  Remove it from the CI to stop getting failed run emails.

Remove python2 and kodi <19 from publishing in next major release