### PR TITLE
Fix bug with multiple external subtitles in the same languages

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -891,9 +891,7 @@ def external_subs(media_source, list_item, item_id):
     sub_names = []
 
     server = settings.getSetting('server_address')
-
-    for stream in media_streams:
-
+    for idx, stream in enumerate(media_streams):
         if (stream['Type'] == "Subtitle"
                 and stream['IsExternal']
                 and stream['IsTextSubtitleStream']
@@ -911,13 +909,16 @@ def external_subs(media_source, list_item, item_id):
 
             url = '{}{}'.format(server, stream.get('DeliveryUrl'))
             if language:
+                title = str(idx)
+                if stream.get('Title'):
+                    title = stream['Title']
                 '''
                 Starting in 10.8, the server no longer provides language
                 specific download points.  We have to download the file
                 and name it with the language code ourselves so Kodi
                 will parse it correctly
                 '''
-                subtitle_file = download_external_sub(language, codec, url)
+                subtitle_file = download_external_sub(language, codec, url, title)
             else:
                 # If there is no language defined, we can go directly to the server
                 subtitle_file = url

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -424,7 +424,7 @@ def translate_path(path):
         return xbmc.translatePath(path)
 
 
-def download_external_sub(language, codec, url):
+def download_external_sub(language, codec, url, title):
     addon_settings = xbmcaddon.Addon()
     verify_cert = addon_settings.getSetting('verify_cert') == 'true'
 
@@ -433,7 +433,7 @@ def download_external_sub(language, codec, url):
     r.raise_for_status()
 
     # Write the subtitle file to the local filesystem
-    file_name = 'Stream.{}.{}'.format(language, codec)
+    file_name = 'Stream.{}.{}.{}'.format(title, language, codec)
     file_path = py2_decode(
         translate_path('special://temp/{}'.format(file_name))
     )


### PR DESCRIPTION
Fixes a bug when multiple external subtitle files in the same language are provided (only the last one appears).