### PR TITLE
fix sdh/cc/hi subtitle for jellyfin > v10.9.0

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -904,9 +904,8 @@ def external_subs(media_source, list_item, item_id):
                 language = '{}.default'.format(language)
             if language and stream['IsForced']:
                 language = '{}.forced'.format(language)
-            is_sdh = stream.get('Title') and stream['Title'] in ('sdh', 'cc')
-            if language and is_sdh:
-                language = '{}.{}'.format(language, stream['Title'])
+            if language and stream['IsHearingImpaired']:
+                language = '{}.SDH'.format(language)
             codec = stream.get('Codec', '')
 
             url = '{}{}'.format(server, stream.get('DeliveryUrl'))


### PR DESCRIPTION
**Conditon:**
- i have movie with these subtitle file
	- MovieName.en.srt
	- MovieName.en.sdh.srt
- i have jellyfin server 10.10.7
- i have kodi 21.2

**Expected:**
- i can choose between **english** subtitle and **english sdh/cc/hi** subtitle

**Actual:**
- i do not have an option to choose between **english sdh/cc/hi** and **english** subtitle
- i can only choose english subtitle

**Cause**
[jellyfin release v10.9.0](https://github.com/jellyfin/jellyfin/releases/tag/v10.9.0) - [Add hearing impaired subtitle stream indicator](https://github.com/jellyfin/jellyfin/pull/7379) introduce new update for common naming convention for external hearing-impaired / close captioned / deaf hearing subtitles

this PR fix problem caused by those release update, following [kodi naming convention for closed
captions](https://kodi.wiki/view/Settings/Player/Subtitles#Enable_parsing_for_closed_captions)

Question:
- should i keep compatibilty for jellyfin release before v10.9.0?