### PR TITLE
Fix websocket reconnects

### DIFF
--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -269,8 +269,7 @@ class WebSocketClient(threading.Thread):
 
         while not self.monitor.abortRequested():
 
-            time.sleep(self.retry_count * 5)
-            self._client.run_forever(ping_interval=10)
+            self._client.run_forever(ping_interval=5, reconnect=13, ping_timeout=2)
 
             if self._stop_websocket:
                 break


### PR DESCRIPTION
Jellycon has the same issue as jellyfin-kodi had: https://github.com/jellyfin/jellyfin-kodi/issues/797

Basically they're utilizing the reconnect options of the websocket library instead of relying on them erroring out and triggering another iteration of the loop the connect runs in.

My jellyfin server is restarted every night for backup purposes. The settings from this pull-request are working fine for some weeks  now.