### PR TITLE
Fix SyntaxWarning in regex

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -100,12 +100,10 @@ def send_event_notification(method, data=None, hexlify=False):
 def datetime_from_string(time_string):
 
     # Builtin python library can't handle ISO-8601 well. Make it compatible
-    if time_string[-1:] == "Z":
+    if time_string.endswith("Z"):
         time_string = re.sub("[0-9]{1}Z", " UTC", time_string)
-    elif time_string[-6:] == "+00:00":
-        time_string = re.sub(
-            "[0-9]{1}\+00:00", " UTC", time_string  # noqa: W605
-        )
+    elif time_string.endswith("+00:00"):
+        time_string = re.sub(r"[0-9]{1}\+00:00", " UTC", time_string)
 
     try:
         dt = datetime.strptime(time_string, "%Y-%m-%dT%H:%M:%S.%f %Z")


### PR DESCRIPTION
This warning was introduced in [Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes):

    plugin.video.jellycon/resources/lib/utils.py:107: SyntaxWarning:
      "\+" is an invalid escape sequence.
      Such sequences will not work in the future.
      Did you mean "\\+"? A raw string is also an option.