### PR TITLE
Add timeout to HTTP requests

### DIFF
--- a/resources/lib/jellyfin.py
+++ b/resources/lib/jellyfin.py
@@ -37,8 +37,8 @@ class API:
 
         url = '{}{}'.format(self.server, path)
 
-        r = requests.get(url, headers=self.headers, verify=self.verify_cert)
         try:
+            r = requests.get(url, headers=self.headers, verify=self.verify_cert, timeout=5)
             try:
                 '''
                 The requests library defaults to using simplejson to handle
@@ -61,8 +61,8 @@ class API:
 
         url = '{}{}'.format(self.server, url)
 
-        r = requests.post(url, json=payload, headers=self.headers, verify=self.verify_cert)
         try:
+            r = requests.post(url, json=payload, headers=self.headers, verify=self.verify_cert, timeout=5)
             try:
                 # Much faster on low power devices, see above comment
                 response_data = json.loads(r.text)
@@ -78,7 +78,10 @@ class API:
 
         url = '{}{}'.format(self.server, url)
 
-        requests.delete(url, headers=self.headers, verify=self.verify_cert)
+        try:
+            requests.delete(url, headers=self.headers, verify=self.verify_cert, timeout=5)
+        except:  # noqa
+            pass
 
     def authenticate(self, auth_data):
         # Always force create fresh headers during authentication

--- a/resources/lib/jellyfin.py
+++ b/resources/lib/jellyfin.py
@@ -38,7 +38,7 @@ class API:
         url = '{}{}'.format(self.server, path)
 
         try:
-            r = requests.get(url, headers=self.headers, verify=self.verify_cert, timeout=5)
+            r = requests.get(url, headers=self.headers, verify=self.verify_cert, timeout=(5,60))
             try:
                 '''
                 The requests library defaults to using simplejson to handle
@@ -80,7 +80,7 @@ class API:
 
         try:
             requests.delete(url, headers=self.headers, verify=self.verify_cert, timeout=5)
-        except:  # noqa
+        except Exception:
             pass
 
     def authenticate(self, auth_data):

--- a/resources/lib/jellyfin.py
+++ b/resources/lib/jellyfin.py
@@ -51,7 +51,7 @@ class API:
                 response_data = json.loads(r.text)
             except ValueError:
                 response_data = r.json()
-        except:  # noqa
+        except Exception:
             response_data = {}
         return response_data
 
@@ -68,7 +68,7 @@ class API:
                 response_data = json.loads(r.text)
             except ValueError:
                 response_data = r.json()
-        except:  # noqa
+        except Exception:
             response_data = {}
         return response_data
 


### PR DESCRIPTION
Added timeout parameter to GET, POST, and DELETE requests to improve resiliency and prevent UI hangs.

The most important change is to the POST request which is used to update playback state. If this POST request has no response with no timeout value, the Kodi video player UI will become unresponsive.

In Kodi, Jellycon hooks into the seek callback which is synchronous. So after a seek, if the Jellycon POST request to update playback state hangs, then the Kodi player UI will also hang.