### PR TITLE
Exclude br compression from requests

### DIFF
--- a/resources/lib/jellyfin.py
+++ b/resources/lib/jellyfin.py
@@ -132,6 +132,9 @@ class API:
                 self.token = token
                 headers['Authorization'] += ", Token={}".format(self.token)
 
+        # Kodi doesn't support br compression, exclude it
+        headers['Accept-Encoding'] = 'gzip, deflate, zstd'
+
         # Make headers available to api calls
         self.headers = headers
 


### PR DESCRIPTION
Intermittent issue where some api calls return malformed data, particularly when testing jellyfin 12.0.  br compression is supported by a third party library that isn't shipped for kodi.  Just exclude it from our requests to avoid the problems.