### PR TITLE
Fix exception when setting season/episode sort number

### DIFF
--- a/resources/lib/item_functions.py
+++ b/resources/lib/item_functions.py
@@ -142,6 +142,11 @@ def extract_item_info(item, gui_options):
     if not item_details.episode_number:
         item_details.episode_number = 0
 
+    if not item_details.season_sort_number:
+        item_details.season_sort_number = 0
+    if not item_details.episode_sort_number:
+        item_details.episode_sort_number = 0
+
     if item.get("Taglines", []):
         item_details.tagline = item.get("Taglines")[0]
 


### PR DESCRIPTION
These sort values must be integers, but can end up being set to `None` when an episode has no season/episode number (such as daily shows):

https://github.com/jellyfin/jellycon/blob/7b5d8be2fbb950e0244f00afa409de60043af366/resources/lib/item_functions.py#L108-L110