### PR TITLE
intro-skipper: fix skip dialog showing after clicking

### DIFF
--- a/resources/lib/dialogs.py
+++ b/resources/lib/dialogs.py
@@ -216,7 +216,7 @@ class SkipDialog(xbmcgui.WindowXMLDialog):
     start = None
     end = None
     
-    has_been_dissmissed = False
+    has_been_dismissed_or_skipped = False
 
     def __init__(self, *args, **kwargs):
         log.debug("SkipDialog: __init__")
@@ -239,7 +239,7 @@ class SkipDialog(xbmcgui.WindowXMLDialog):
         log.debug("SkipDialog: onAction: {0}".format(action.getId()))
         if action.getId() == 10 or action.getId() == 92:  # ACTION_PREVIOUS_MENU & ACTION_NAV_BACK
             log.debug("SkipDialog: dismissing dialog so it does not open again")
-            self.has_been_dissmissed = True
+            self.has_been_dismissed_or_skipped = True
             self.close()
 
     def onClick(self, control_id):
@@ -250,7 +250,8 @@ class SkipDialog(xbmcgui.WindowXMLDialog):
             log.debug("SkipDialog: skipping segment because current ticks ({0}) is in range".format(current_ticks))
             # If click during segment, skip it
             player.seekTime(ticks_to_seconds(self.end))
-                                        
+            # mark dialog as skipped to avoid opening again
+            self.has_been_dismissed_or_skipped = True
         self.close()
 
     def get_play_called(self):

--- a/resources/lib/intro_skipper.py
+++ b/resources/lib/intro_skipper.py
@@ -96,9 +96,9 @@ class IntroSkipperService(threading.Thread):
         is_segment = False
         if dialog.start is not None and dialog.end is not None:
             # Resets the dismiss var so that button can reappear in case of navigation in the timecodes
-            if (current_ticks < dialog.start or current_ticks > dialog.end) and dialog.has_been_dissmissed is True:
+            if (current_ticks < dialog.start or current_ticks > dialog.end) and dialog.has_been_dismissed_or_skipped is True:
                 log.debug("SkipService: {0} skip was dismissed. It is reset beacause timecode is outside of segment")
-                dialog.has_been_dissmissed = False
+                dialog.has_been_dismissed_or_skipped = False
 
             # Checks if segment is playing
             is_segment = current_ticks >= dialog.start and current_ticks <= dialog.end
@@ -110,7 +110,7 @@ class IntroSkipperService(threading.Thread):
                 xbmcgui.Dialog().notification("JellyCon", "{0} Skipped".format(segment_type))
             elif skip_action == "0":
                 # Otherwise show skip dialog
-                if is_segment and not dialog.has_been_dissmissed:
+                if is_segment and not dialog.has_been_dismissed_or_skipped:
                     log.debug("SkipService: {0} is playing, showing dialog".format(segment_type))
                     dialog.show()
                 else:

--- a/resources/lib/intro_skipper_utils.py
+++ b/resources/lib/intro_skipper_utils.py
@@ -56,7 +56,7 @@ def set_correct_skip_info(item_id: str, skip_dialog: SkipDialog, segment: dict):
         # If playback item has changed (or is new), sets its id and set media segments info
         log.debug("SkipDialogInfo : Media Id has changed to {0}, setting segments".format(item_id))
         skip_dialog.media_id = item_id
-        skip_dialog.has_been_dissmissed = False
+        skip_dialog.has_been_dismissed_or_skipped = False
         if segment is not None:
             # Find the intro and outro timings
             start = segment.get("StartTicks")


### PR DESCRIPTION
The skip dialog can sometimes be shown again after being pressed.
Here is a video of it happening:
[without_fix.webm](https://github.com/user-attachments/assets/2be5db6f-8ac2-4e1d-bb1b-109f510c81b2)

This change uses the same flag as when the dialog is dismissed to avoid showing the same dialog again.
Here is a video with the fix:
[with_fix.webm](https://github.com/user-attachments/assets/b2f3a5c8-6519-4d4b-95b9-214b6457bea8)
