### PR TITLE
Fix resume position bug

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -1386,7 +1386,6 @@ class Service(xbmc.Player):
 
     def onPlayBackStarted(self):
         # Will be called when xbmc starts playing a file
-        stop_all_playback()
 
         if not xbmc.Player().isPlaying():
             log.debug("onPlayBackStarted: not playing file!")


### PR DESCRIPTION
Fixes critical bug where resuming videos would break position tracking for all subsequent playback, requiring a Kodi restart to restore functionality.

Root Cause:
When onPlayBackStarted() was called (including on resume), it called stop_all_playback() which cleared the 'now_playing' HomeWindow property. Then get_playing_data() tried to read this empty property and returned {}. This caused onPlayBackStarted() to exit early without setting currently_playing=True, which prevented all future position updates.

The Fix:
Removed stop_all_playback() call from onPlayBackStarted(). This call was inappropriate - starting playback should not trigger stop logic. Playback stops are properly handled by onPlayBackStopped() and onPlayBackEnded().

Impact:
- Fixes position tracking for resumed videos
- Fixes position tracking after multiple play/stop cycles
- No longer requires Kodi restart when state corruption occurs
- All existing functionality preserved

Technical Details:
The stop_all_playback() call at the start of onPlayBackStarted() would:
1. Clear the now_playing HomeWindow property (line 1135)
2. Cause get_playing_data() to return empty dict (line 1245)
3. Trigger early return before currently_playing flag was set (line 1409)
4. Leave playback state corrupted for all subsequent stops

This only manifested on resume because first playback works before any stop_all_playback() has cleared the property. The bug affected all users who resume videos but was difficult to diagnose without enhanced logging.

Note: I've been testing this fix for several days now and it appear to be working.

---